### PR TITLE
add actions that reload authorities in the application

### DIFF
--- a/.github/workflows/reload-auths-int.yml
+++ b/.github/workflows/reload-auths-int.yml
@@ -1,0 +1,20 @@
+# When syncing of configs from github to S3 is complete and required time passes to
+# allow for syncing of S3 to application, reloads the authorities in the application.
+# See sync-s3-int.yml for the sync and wait workflow.
+name: reload-auths-int
+
+on:
+  workflow_dispatch:   # allow for manually running through Actions tab
+  workflow_run:        # runs when sync-s3-int completes
+    workflows: ["sync-s3-int"]
+    types:
+      - completed
+
+jobs:
+  reload_auths:
+    runs-on: ubuntu-latest
+    environment: integration
+    steps:
+      - name: reload authorities
+        run:
+          curl https://qa-server-service-int.library.cornell.edu/authorities/reload/linked_data/authorities${{ secrets.AUTHENTICATE_RELOAD }}

--- a/.github/workflows/reload-auths-prod.yml
+++ b/.github/workflows/reload-auths-prod.yml
@@ -1,0 +1,20 @@
+# When syncing of configs from github to S3 is complete and required time passes to
+# allow for syncing of S3 to application, reloads the authorities in the application.
+# See sync-s3-prod.yml for the sync and wait workflow.
+name: reload-auths-prod
+
+on:
+  workflow_dispatch:   # allow for manually running through Actions tab
+#  workflow_run:        # runs when sync-s3-prod completes  -- TURNED OFF --
+#    workflows: ["sync-s3-prod"]
+#    types:
+#      - completed
+
+jobs:
+  reload_auths:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: reload authorities
+        run:
+          curl https://qa-server-service-prod.library.cornell.edu/authorities/reload/linked_data/authorities${{ secrets.AUTHENTICATE_RELOAD }}

--- a/.github/workflows/reload-auths-stg.yml
+++ b/.github/workflows/reload-auths-stg.yml
@@ -1,0 +1,20 @@
+# When syncing of configs from github to S3 is complete and required time passes to
+# allow for syncing of S3 to application, reloads the authorities in the application.
+# See sync-s3-stg.yml for the sync and wait workflow.
+name: reload-auths-stg
+
+on:
+  workflow_dispatch:   # allow for manually running through Actions tab
+  workflow_run:        # runs when sync-s3-stg completes
+    workflows: ["sync-s3-stg"]
+    types:
+      - completed
+
+jobs:
+  reload_auths:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: reload authorities
+        run:
+          curl https://qa-server-service-stg.library.cornell.edu/authorities/reload/linked_data/authorities${{ secrets.AUTHENTICATE_RELOAD }}

--- a/.github/workflows/sync-s3-prod.yml
+++ b/.github/workflows/sync-s3-prod.yml
@@ -5,8 +5,11 @@ name: sync-s3-prod
 
 on:
   workflow_dispatch:  # allow for manually running through Actions tab
-  push:
-    branches: [ main ] # auto-run when files in listed paths change in the main branch
+#  push:    -- TURNED OFF --
+#    branches: [ main ] # auto-run when files in listed paths change in the main branch
+#    paths:
+#      - 'config/authorities/**'
+#      - 'config/locales/**'
 
 jobs:
   s3_update:


### PR DESCRIPTION
NOTE: Once sync-s3-* actions complete, it takes about an hour before changes to authorities are synced into the application.  These actions should be run an hour after the S3 sync completes.