### PR TITLE
add wait time to end of sync-s3-* actions

### DIFF
--- a/.github/workflows/sync-s3-int.yml
+++ b/.github/workflows/sync-s3-int.yml
@@ -27,3 +27,11 @@ jobs:
           AWS_REGION: 'us-east-1'
           SOURCE_DIR: 'config'
           DEST_DIR: 'config'
+  wait_one_hour:
+    # reload-auths-int workflow watches for the end of this workflow before reloading auths in the app
+    needs: s3_update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/auto-cancel-redundant-workflow@v1
+      - name: wait-one-hour
+        run: sleep 1h

--- a/.github/workflows/sync-s3-prod.yml
+++ b/.github/workflows/sync-s3-prod.yml
@@ -27,3 +27,11 @@ jobs:
           AWS_REGION: 'us-east-1'
           SOURCE_DIR: 'config'
           DEST_DIR: 'config'
+#  wait_one_hour: # currently, reload-auths-prod is configured for manual trigger only -- TURNED OFF --
+#    # reload-auths-prod workflow watches for the end of this workflow before reloading auths in the app
+#    needs: s3_update
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: technote-space/auto-cancel-redundant-workflow@v1
+#      - name: wait-one-hour
+#        run: sleep 1h

--- a/.github/workflows/sync-s3-stg.yml
+++ b/.github/workflows/sync-s3-stg.yml
@@ -27,3 +27,11 @@ jobs:
           AWS_REGION: 'us-east-1'
           SOURCE_DIR: 'config'
           DEST_DIR: 'config'
+  wait_one_hour:
+    # reload-auths-stg workflow watches for the end of this workflow before reloading auths in the app
+    needs: s3_update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/auto-cancel-redundant-workflow@v1
+      - name: wait-one-hour
+        run: sleep 1h


### PR DESCRIPTION
The wait time is used to delay the execution of reload-auths-* actions.  This provides time for the sync from S3 to the application to complete.

FUTURE WORK: Determine if there is a way to schedule the execution of reload-auths-* instead of using Unix sleep.