### PR TITLE
Update aws-deploy.yaml

### DIFF
--- a/deploy-templates/aws-deploy.yaml
+++ b/deploy-templates/aws-deploy.yaml
@@ -110,7 +110,7 @@ Resources:
             - Type: s3
               Value: !Join ["", ["arn:aws:s3:::", !Ref S3BucketName, "/", !Ref EnvFileName]]
           Essential: True
-          Image: mariadb:latest
+          Image: mariadb:10.7.4
           LogConfiguration: 
             LogDriver: awslogs
             Options:


### PR DESCRIPTION
MariaDB 10.8.x has moved its base image from Debian-focal to Debian-jammy which is a breaking change in the version of Docker running on ECS. Therefore, pinning the version at 10.7.4 which is long term stable and should be for a while.