### PR TITLE
Create direct linked data lookups for homosaurus and getty

### DIFF
--- a/config/authorities/linked_data/getty_direct.json
+++ b/config/authorities/linked_data/getty_direct.json
@@ -1,0 +1,83 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "prefixes": {
+    "getty":   "http://vocab.getty.edu/ontology#"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "https://vocab.getty.edu/{subauth}/{term_id}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_id",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        },
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "subauth",
+          "property": "hydra:freetextQuery",
+          "required": true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_id",
+      "subauth": "subauth"
+    },
+    "term_id": "ID",
+    "results": {
+      "id_ldpath":       "dc:identifier :: xsd:string",
+      "label_ldpath":    "skos:prefLabel :: xsd:string",
+      "altlabel_ldpath": "skos:altLabel :: xsd:string",
+      "broader_ldpath":  "skos:broader :: xsd:anyURI",
+      "narrower_ldpath": "skos:narrower :: xsd:anyURI",
+      "sameas_ldpath":   "skos:exactMatch :: xsd:anyURI"
+    },
+    "subauthorities": {
+      "aat":  "aat",
+      "tgn":  "tgn",
+      "ulan": "ulan"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "https://vocab.getty.edu/sparql.rdf?query=CONSTRUCT+%7B%3Fs+dc%3Aidentifier+%3Fid%3B+skos%3AprefLabel+%3FprefLabel.%7D%0AWHERE+%7B%3Fs+a+skos%3AConcept%3B+luc%3Aterm+%22{query}%22%3B+skos%3AinScheme+{subauth}%3A%3B+skos%3AprefLabel+%3FprefLabel.%0A++%3Fs+dc%3Aidentifier+%3Fid.%0A++BIND%28REPLACE%28%22{query}%22%2C+%22%5B%2C*%28%29%5D%22%2C+%22%22%2C+%22i%22%29+AS+%3Fstripped_query%29.%0A++BIND%28REPLACE%28%3Fstripped_query%2C+%22%5C%5Cs*%28%5C%5CS%2B%29%5C%5Cs*%22%2C+%22%28%3F%3D.*%241%29%22%29+AS+%3Ffilter_query%29.%0A++FILTER+regex%28str%28%3FprefLabel%29%2C+%3Ffilter_query%2C+%22i%22%29.%0A%7D+ORDER+BY+asc%28lcase%28str%28%3FprefLabel%29%29%29&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "subauth",
+          "property": "hydra:freetextQuery",
+          "required": true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "subauth": "subauth"
+    },
+    "results": {
+      "id_ldpath":    "dc:identifier :: xsd:string",
+      "label_ldpath": "skos:prefLabel :: xsd:string"
+    },
+    "subauthorities": {
+      "aat":  "aat",
+      "tgn":  "tgn",
+      "ulan": "ulan"
+    }
+  }
+}

--- a/config/authorities/linked_data/getty_direct.json
+++ b/config/authorities/linked_data/getty_direct.json
@@ -1,7 +1,7 @@
 {
   "QA_CONFIG_VERSION": "2.2",
   "prefixes": {
-    "getty":   "http://vocab.getty.edu/ontology#"
+    "gvp":   "http://vocab.getty.edu/ontology#"
   },
   "term": {
     "url": {
@@ -48,7 +48,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "https://vocab.getty.edu/sparql.rdf?query=CONSTRUCT+%7B%3Fs+dc%3Aidentifier+%3Fid%3B+skos%3AprefLabel+%3FprefLabel.%7D%0AWHERE+%7B%3Fs+a+skos%3AConcept%3B+luc%3Aterm+%22{query}%22%3B+skos%3AinScheme+{subauth}%3A%3B+skos%3AprefLabel+%3FprefLabel.%0A++%3Fs+dc%3Aidentifier+%3Fid.%0A++BIND%28REPLACE%28%22{query}%22%2C+%22%5B%2C*%28%29%5D%22%2C+%22%22%2C+%22i%22%29+AS+%3Fstripped_query%29.%0A++BIND%28REPLACE%28%3Fstripped_query%2C+%22%5C%5Cs*%28%5C%5CS%2B%29%5C%5Cs*%22%2C+%22%28%3F%3D.*%241%29%22%29+AS+%3Ffilter_query%29.%0A++FILTER+regex%28str%28%3FprefLabel%29%2C+%3Ffilter_query%2C+%22i%22%29.%0A%7D+ORDER+BY+asc%28lcase%28str%28%3FprefLabel%29%29%29&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql",
+      "template": "https://vocab.getty.edu/sparql.rdf?query=CONSTRUCT+%7B%3Fs+dc%3Aidentifier+%3Fid%3B+skos%3AprefLabel+%3FprefLabel%3B+gvp%3AparentString+%3Fparent.%7D%0AWHERE+%7B%3Fs+a+skos%3AConcept%3B+luc%3Aterm+%22{query}%22%3B+skos%3AinScheme+{subauth}%3A%3B+skos%3AprefLabel+%3FprefLabel%3B+dc%3Aidentifier+%3Fid.%0A++OPTIONAL+%7B%3Fs+gvp%3AparentString+%3Fparent%7D%0A++BIND%28REPLACE%28%22{query}%22%2C+%22%5B%2C*%28%29%5D%22%2C+%22%22%2C+%22i%22%29+AS+%3Fstripped_query%29.%0A++BIND%28REPLACE%28%3Fstripped_query%2C+%22%5C%5Cs*%28%5C%5CS%2B%29%5C%5Cs*%22%2C+%22%28%3F%3D.*%241%29%22%29+AS+%3Ffilter_query%29.%0A++FILTER+regex%28str%28%3FprefLabel%29%2C+%3Ffilter_query%2C+%22i%22%29.%0A%7D+ORDER+BY+asc%28lcase%28str%28%3FprefLabel%29%29%29&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -71,13 +71,22 @@
       "subauth": "subauth"
     },
     "results": {
-      "id_ldpath":    "dc:identifier :: xsd:string",
-      "label_ldpath": "skos:prefLabel :: xsd:string"
+      "id_ldpath":     "dc:identifier :: xsd:string",
+      "label_ldpath":  "skos:prefLabel :: xsd:string"
     },
     "subauthorities": {
       "aat":  "aat",
       "tgn":  "tgn",
       "ulan": "ulan"
+    },
+    "context": {
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_direct.parent_body",
+          "property_label_default": "Parent Body",
+          "ldpath": "gvp:parentString :: xsd:string"
+        }
+      ]
     }
   }
 }

--- a/config/authorities/linked_data/homosaurus_direct.json
+++ b/config/authorities/linked_data/homosaurus_direct.json
@@ -1,0 +1,59 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "prefixes": {
+    "dcterms": "http://purl.org/dc/terms/"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "https://homosaurus.org/v3/{term_id}.jsonld",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_id",
+          "property": "hydra:freetextQuery",
+          "required": true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_id"
+    },
+    "term_id": "ID",
+    "results": {
+      "id_ldpath":       "dcterms:identifier",
+      "label_ldpath":    "skos:prefLabel :: xsd:string",
+      "altlabel_ldpath": "skos:altLabel :: xsd:string",
+      "narrower_ldpath": "skos:narrower :: xsd:anyURI",
+      "broader_ldpath":  "skos:broader :: xsd:anyURI",
+      "sameas_ldpath":   "skos:exactMatch :: xsd:anyURI"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "https://homosaurus.org/search/v3.jsonld?q={query}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query"
+    },
+    "results": {
+      "id_ldpath":    "dcterms:identifier",
+      "label_ldpath": "skos:prefLabel :: xsd:string",
+      "sort_ldpath":  "skos:prefLabel :: xsd:string"
+    }
+  }
+}

--- a/config/authorities/linked_data/homosaurus_direct.json
+++ b/config/authorities/linked_data/homosaurus_direct.json
@@ -52,8 +52,7 @@
     },
     "results": {
       "id_ldpath":    "dcterms:identifier",
-      "label_ldpath": "skos:prefLabel :: xsd:string",
-      "sort_ldpath":  "skos:prefLabel :: xsd:string"
+      "label_ldpath": "skos:prefLabel :: xsd:string"
     }
   }
 }

--- a/config/authorities/linked_data/homosaurus_direct.json
+++ b/config/authorities/linked_data/homosaurus_direct.json
@@ -53,6 +53,30 @@
     "results": {
       "id_ldpath":    "dcterms:identifier",
       "label_ldpath": "skos:prefLabel :: xsd:string"
+    },
+    "context": {
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.homosaurus_direct.identifier",
+          "property_label_default": "Identifier",
+          "ldpath": "dcterms:identifier :: xsd:string"
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.homosaurus_direct.preferred_label",
+          "property_label_default": "Preferred Label",
+          "ldpath": "skos:prefLabel :: xsd:string"
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.homosaurus_direct.alt_label",
+          "property_label_default": "Alt Label",
+          "ldpath": "skos:altLabel :: xsd:string"
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.homosaurus_direct.scope",
+          "property_label_default": "Scope",
+          "ldpath": "rdfs:comment :: xsd:string"
+        }
+      ]
     }
   }
 }

--- a/config/authorities/linked_data/scenarios/getty_direct_validation.yml
+++ b/config/authorities/linked_data/scenarios/getty_direct_validation.yml
@@ -146,11 +146,6 @@ search:
     position: 5
     subject_uri: "http://vocab.getty.edu/aat/300262795"
   -
-    query: demonstrations
-    subauth: aat
-    position: 5
-    subject_uri: "http://vocab.getty.edu/aat/300262795"
-  -
     query: ontology
     subauth: aat
     position: 5
@@ -165,11 +160,6 @@ search:
     subauth: aat
     position: 5
     subject_uri: "http://vocab.getty.edu/aat/300264364"
-  -
-    query: gestabiliseerd
-    subauth: aat
-    position: 5
-    subject_uri: "http://vocab.getty.edu/aat/300163757"
   -
     query: disidente
     subauth: aat
@@ -296,14 +286,14 @@ search:
     position: 3
     subject_uri: "http://vocab.getty.edu/tgn/2069433"
   -
-    query: Boulder, CO
+    query: Boulder
     subauth: tgn
-    position: 3
+    position: 30
     subject_uri: "http://vocab.getty.edu/tgn/2000198"
   -
-    query: Paris, France
+    query: Paris
     subauth: tgn
-    position: 10
+    position: 50
     subject_uri: "http://vocab.getty.edu/tgn/7008038"
   -
     query: Nile River
@@ -328,7 +318,6 @@ search:
   -
     query: University of Chicago Library
     subauth: ulan
-    result_size: 100
     subject_uri: "http://vocab.getty.edu/ulan/500304715"
     position: 5
 term:

--- a/config/authorities/linked_data/scenarios/getty_direct_validation.yml
+++ b/config/authorities/linked_data/scenarios/getty_direct_validation.yml
@@ -1,0 +1,342 @@
+---
+authority:
+  service: direct
+search:
+  #------------------
+  # Connection tests
+  #------------------
+  -
+    query: amphora
+    subauth: aat
+  -
+    query: events
+    subauth: aat
+  -
+    query: film
+    subauth: aat
+    result_size: 90
+  -
+    query: exhibitions
+    subauth: aat
+  -
+    query:  inspection
+    subauth: aat
+    result_size: 75
+  -
+    query: public speaking
+    subauth: aat
+    result_size: 80
+  -
+    query: transporting
+    subauth: aat
+  -
+    query: domestic
+    subauth: aat
+  -
+    query: domestic
+    subauth: aat
+  -
+    query:  funding agencies
+    subauth: aat
+    result_size: 80
+  -
+    query: domestic
+    subauth: aat
+    result_size: 170
+  -
+    query: social science
+    subauth: aat
+    result_size: 90
+  -
+    query: air quality
+    subauth: aat
+    result_size: 160
+  -
+    query: brand name additives
+    subauth: aat
+    result_size: 80
+  -
+    query: tyvek
+    subauth: aat
+    result_size: 70
+  -
+    query: copper
+    subauth: aat
+  -
+    query: copper
+    subauth: aat
+  -
+    query: built environment
+    subauth: aat
+  -
+    query: backstops
+    subauth: aat
+    result_size: 70
+  -
+    query: reveals
+    subauth: aat
+    result_size: 70
+  -
+    query: Boston rocker
+    subauth: aat
+    result_size: 80
+  -
+    query: natural objects
+    subauth: aat
+    result_size: 80
+  -
+    query: libraries
+    subauth: aat
+    result_size: 180
+  -
+    query: admission ticket
+    subauth: aat
+    result_size: 80
+  -
+    query: density
+    subauth: aat
+    result_size: 70
+  -
+    query: density
+    subauth: aat
+    result_size: 70
+  -
+    query: pearl
+    subauth: aat
+    result_size: 80
+  -
+    query: cracks
+    subauth: aat
+  -
+    query: compass roses
+    subauth: aat
+    result_size: 80
+  -
+    query: Contemporary
+    subauth: aat
+    result_size: 190
+  -
+    query: Contemporary
+    subauth: aat
+    result_size: 190
+  -
+    query: memphis
+    subauth: tgn
+  -
+    query: washington
+    subauth: ulan
+  -
+    query: washington
+    subauth: ulan
+  -
+    query: washington
+    subauth: ulan
+  #------------------
+  #  Accuracy tests
+  #------------------
+  -
+    query: precious
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300011054"
+  -
+    query: demonstrations
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300262795"
+  -
+    query: demonstrations
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300262795"
+  -
+    query: ontology
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300054295"
+  -
+    query: lobbying
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300077524"
+  -
+    query: bhāvanā
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300264364"
+  -
+    query: gestabiliseerd
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300163757"
+  -
+    query: disidente
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300136713"
+  -
+    query: RNA
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300410331"
+  -
+    query: printmaking studios
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300312299"
+  -
+    query: alter egos
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300435335"
+  -
+    query: credit
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300055706"
+  -
+    query: palindrome
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300417834"
+  -
+    query: Crayola Cutter (TM)
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300391344"
+  -
+    query: Masonite
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300014205"
+  -
+    query: mesh
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300014654"
+  -
+    query: residuo tóxico
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300253882"
+  -
+    query: lloy lloy
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300410934"
+  -
+    query: areas, protected
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300386975"
+  -
+    query: gewelfschotels
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300391167"
+  -
+    query: dung-chen
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300222195"
+  -
+    query: oggetti (realia)
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300265419"
+  -
+    query: VistaVision (TM)
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300264671"
+  -
+    query: hours
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300404017"
+  -
+    query: serpentiforme
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300311305"
+  -
+    query: 不穩定性
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300221189"
+  -
+    query: eggplant
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300311492"
+  -
+    query: microwear
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300249983"
+  -
+    query: filigrana
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300220293"
+  -
+    query: Ontarian
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300386484"
+  -
+    query: old-fashioned
+    subauth: aat
+    position: 5
+    subject_uri: "http://vocab.getty.edu/aat/300312275"
+  -
+    query: Gouverneur
+    subauth: tgn
+    position: 3
+    subject_uri: "http://vocab.getty.edu/tgn/2069433"
+  -
+    query: Boulder, CO
+    subauth: tgn
+    position: 3
+    subject_uri: "http://vocab.getty.edu/tgn/2000198"
+  -
+    query: Paris, France
+    subauth: tgn
+    position: 10
+    subject_uri: "http://vocab.getty.edu/tgn/7008038"
+  -
+    query: Nile River
+    subauth: tgn
+    position: 3
+    subject_uri: "http://vocab.getty.edu/tgn/1127805"
+  -
+    query: Gonzalez-Torres, Felix
+    subauth: ulan
+    subject_uri: "http://vocab.getty.edu/ulan/500114715"
+    position: 5
+  -
+    query: Gouverneur
+    subauth: ulan
+    subject_uri: "http://vocab.getty.edu/ulan/500225342"
+    position: 5
+  -
+    query: Octavio Medellin
+    subauth: ulan
+    subject_uri: "http://vocab.getty.edu/ulan/500333005"
+    position: 3
+  -
+    query: University of Chicago Library
+    subauth: ulan
+    result_size: 100
+    subject_uri: "http://vocab.getty.edu/ulan/500304715"
+    position: 5
+term:
+  -
+    identifier: "300265730"
+    subauth: aat
+  -
+    identifier: 7017750"
+    subauth: tgn
+  -
+    identifier: "500020427"
+    subauth: ulan

--- a/config/authorities/linked_data/scenarios/getty_direct_validation.yml
+++ b/config/authorities/linked_data/scenarios/getty_direct_validation.yml
@@ -29,6 +29,7 @@ search:
   -
     query: transporting
     subauth: aat
+    result_size: 1
   -
     query: domestic
     subauth: aat
@@ -335,7 +336,7 @@ term:
     identifier: "300265730"
     subauth: aat
   -
-    identifier: 7017750"
+    identifier: "7017750"
     subauth: tgn
   -
     identifier: "500020427"

--- a/config/authorities/linked_data/scenarios/homosaurus_direct_validation.yml
+++ b/config/authorities/linked_data/scenarios/homosaurus_direct_validation.yml
@@ -1,0 +1,51 @@
+---
+authority:
+  service: direct
+search:
+  #------------------
+  # Connection tests
+  #------------------
+  -
+    query: ze
+  -
+    query: Dating applications
+  #------------------
+  #  Accuracy tests
+  #------------------
+  -
+    query: aro
+    subject_uri: "https://homosaurus.org/v3/homoit0001753"
+    position: 3
+  -
+    query: Ve/Vem/Verself (Pronouns)
+    subject_uri: "https://homosaurus.org/v3/homoit0001699"
+    position: 1
+  -
+    query: Dating apps
+    position: 3
+    subject_uri: "https://homosaurus.org/v3/homoit0000328"
+  -
+    query: LGBTQ+
+    position: 60
+    subject_uri: "https://homosaurus.org/v3/homoit0001717"
+  -
+    query: LGBTQ+
+    position: 15
+    subject_uri: "https://homosaurus.org/v3/homoit0000806"
+  -
+    query: E (Pronouns)
+    position: 3
+    subject_uri: "https://homosaurus.org/v3/homoit0001676"
+  -
+    query: pronouns
+    position: 50
+    subject_uri: "https://homosaurus.org/v3/homoit0001692"
+  -
+    query: drug use recreational
+    position: 5
+    subject_uri: "https://homosaurus.org/v3/homoit0001235"
+term:
+  -
+    identifier: "homoit0001673"
+  -
+    identifier: "homoit0000806"

--- a/config/authorities/linked_data/scenarios/homosaurus_direct_validation.yml
+++ b/config/authorities/linked_data/scenarios/homosaurus_direct_validation.yml
@@ -22,27 +22,27 @@ search:
     position: 1
   -
     query: Dating apps
-    position: 3
+    position: 1
     subject_uri: "https://homosaurus.org/v3/homoit0000328"
   -
     query: LGBTQ+
-    position: 60
+    position: 176
     subject_uri: "https://homosaurus.org/v3/homoit0001717"
   -
     query: LGBTQ+
-    position: 15
+    position: 88
     subject_uri: "https://homosaurus.org/v3/homoit0000806"
   -
     query: E (Pronouns)
-    position: 3
+    position: 1
     subject_uri: "https://homosaurus.org/v3/homoit0001676"
   -
     query: pronouns
-    position: 50
+    position: 22
     subject_uri: "https://homosaurus.org/v3/homoit0001692"
   -
     query: drug use recreational
-    position: 5
+    position: 6
     subject_uri: "https://homosaurus.org/v3/homoit0001235"
 term:
   -

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -7,3 +7,8 @@ en:
       copyright_html:   "<strong>Copyright &copy; 2018-2022 Cornell</strong> Licensed under the Apache License, Version 2.0"
       service_html:     A service of <a href="http://www.library.cornell.edu/" class="navbar-link" target="_blank">Cornell University Library</a> and <br /><a href="https://www.slis.uiowa.edu/" class="navbar-link" target="_blank">School of Library and Information Science, University of Iowa</a>.
       attribution_html: This service is supported by work on <a href="http://ld4l.org" class="navbar-link" target="_blank">Linked Data for Libraries - Labs</a> and <br>  <a href="https://wiki.duraspace.org/x/9xgRBg" class="navbar-link" target="_blank">Linked Data for Production</a> funded by <a href="https://mellon.org/" class="navbar-link" target="_blank">Andrew W. Mellon Foundation</a>, <br>and by work on Questioning Authority in <a href="http://samvera.org" class="navbar-link" target="_blank">Samvera</a>, an open source community.
+  qa:
+    linked_data:
+      authority:
+        getty_direct:
+          parent_body: Parent Body

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -12,3 +12,8 @@ en:
       authority:
         getty_direct:
           parent_body: Parent Body
+        homosaurus_direct:
+          preferred_label: Preferred Label
+          alt_label: Alt Label
+          identifier: Identifier
+          scope: Scope


### PR DESCRIPTION
- https://github.com/cul-it/qa_server/issues/374 - Add homosaurus direct lookup
  - Usage:
    - Term retrieval by id: http://localhost:3000/authorities/show/linked_data/homosaurus_direct/homoit0001709
       - QA search url: https://homosaurus.org/v3/homoit0001709.jsonld
    - Search: http://localhost:3000/authorities/search/linked_data/homosaurus_direct?q=Pronouns
       - QA term url: https://homosaurus.org/search/v3.jsonld?q=Pronouns
  - Could not find any documentation on how to adjust search url template to include language or maxRecords parameters
- https://github.com/cul-it/qa_server/issues/384 - Add getty direct lookup
  - Usage:
    - Term retrieval by id (aat subauthority): http://localhost:3000/authorities/show/linked_data/getty_direct/aat/300264973
       - QA term url: https://vocab.getty.edu/aat/300264973
    - Search (aat subauthority): http://localhost:3000/authorities/search/linked_data/getty_direct/aat?q=amphora
       - QA search url: https://vocab.getty.edu/queries?toc=Finding_Subjects&query=CONSTRUCT+%7B%3Fs+dc%3Aidentifier+%3Fid%3B+skos%3AprefLabel+%3FprefLabel.%7D%0AWHERE+%7B%3Fs+a+skos%3AConcept%3B+luc%3Aterm+%22amphora%22%3B+skos%3AinScheme+aat%3A%3B+skos%3AprefLabel+%3FprefLabel.%0A++%3Fs+dc%3Aidentifier+%3Fid.%0A++BIND%28REPLACE%28%22amphora%22%2C+%22%5B%2C*%28%29%5D%22%2C+%22%22%2C+%22i%22%29+AS+%3Fstripped_query%29.%0A++BIND%28REPLACE%28%3Fstripped_query%2C+%22%28%5C%5CS%2B%29%5C%5Cs*%22%2C+%22%28%3F%3D.*%241%29%22%29+AS+%3Ffilter_query%29.%0A++FILTER+regex%28str%28%3FprefLabel%29%2C+%3Ffilter_query%2C+%22i%22%29.%0A%7D+ORDER+BY+asc%28lcase%28str%28%3FprefLabel%29%29%29&implicit=true&equivalent=false#Finding_Subjects
  - Uses subauthorities to differentiate between aat, tgn, and ulan
    - Theoretically, we could break this down further and create separate getty_directs for each aat, tgn, and ulan, and separate subauthorities to match current list from cached ld lookup configs (e.g. https://github.com/cul-it/qa_server_aws_deploy/blob/dev/config/authorities/linked_data/getty_aat_ld4l_cache.json#L154) - will bring this up during testing on int to see if there's a need.
  - Adding a limit to the sparql query only limits # of rows in results, not number of distinct authorities, so couldn't include a maxRecords parameter in the search url template for users
  - This was a pain. I'm basically just trying to massage the user-supplied query directly in the sparql query, and that has limits. Especially when there's logic in the getty docs that wants different handling depending on language and etc.
      - Since the MESH direct lookup may also include a sparql query, we may be able to extrapolate some common sparql-handling logic (e.g. remove stop words and special characters?) and preprocess the user query and search url template in the ruby code. But for now, didn't want to override ld config handling code for a single direct lookup config if we didn't need to.