### PR TITLE
Add local controlled vocabulary for RDA vocabs

### DIFF
--- a/config/authorities/rda_aspect_ratio_designation.yml
+++ b/config/authorities/rda_aspect_ratio_designation.yml
@@ -1,0 +1,10 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/AspectRatio/1001
+      :uri: http://rdaregistry.info/termList/AspectRatio/1001
+      :term: full screen
+    - :id: http://rdaregistry.info/termList/AspectRatio/1003
+      :uri: http://rdaregistry.info/termList/AspectRatio/1003
+      :term: mixed aspect ratio
+    - :id: http://rdaregistry.info/termList/AspectRatio/1002
+      :uri: http://rdaregistry.info/termList/AspectRatio/1002
+      :term: wide screen

--- a/config/authorities/rda_bibliographic_format.yml
+++ b/config/authorities/rda_bibliographic_format.yml
@@ -1,0 +1,46 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/bookFormat/1014
+      :uri: http://rdaregistry.info/termList/bookFormat/1014
+      :term: 128mo
+    - :id: http://rdaregistry.info/termList/bookFormat/1004
+      :uri: http://rdaregistry.info/termList/bookFormat/1004
+      :term: 12mo
+    - :id: http://rdaregistry.info/termList/bookFormat/1005
+      :uri: http://rdaregistry.info/termList/bookFormat/1005
+      :term: 16mo
+    - :id: http://rdaregistry.info/termList/bookFormat/1010
+      :uri: http://rdaregistry.info/termList/bookFormat/1010
+      :term: 18mo
+    - :id: http://rdaregistry.info/termList/bookFormat/1006
+      :uri: http://rdaregistry.info/termList/bookFormat/1006
+      :term: 24mo
+    - :id: http://rdaregistry.info/termList/bookFormat/1007
+      :uri: http://rdaregistry.info/termList/bookFormat/1007
+      :term: 32mo
+    - :id: http://rdaregistry.info/termList/bookFormat/1011
+      :uri: http://rdaregistry.info/termList/bookFormat/1011
+      :term: 36mo
+    - :id: http://rdaregistry.info/termList/bookFormat/1008
+      :uri: http://rdaregistry.info/termList/bookFormat/1008
+      :term: 48mo
+    - :id: http://rdaregistry.info/termList/bookFormat/1002
+      :uri: http://rdaregistry.info/termList/bookFormat/1002
+      :term: 4to
+    - :id: http://rdaregistry.info/termList/bookFormat/1009
+      :uri: http://rdaregistry.info/termList/bookFormat/1009
+      :term: 64mo
+    - :id: http://rdaregistry.info/termList/bookFormat/1012
+      :uri: http://rdaregistry.info/termList/bookFormat/1012
+      :term: 72mo
+    - :id: http://rdaregistry.info/termList/bookFormat/1003
+      :uri: http://rdaregistry.info/termList/bookFormat/1003
+      :term: 8vo
+    - :id: http://rdaregistry.info/termList/bookFormat/1013
+      :uri: http://rdaregistry.info/termList/bookFormat/1013
+      :term: 96mo
+    - :id: http://rdaregistry.info/termList/bookFormat/1001
+      :uri: http://rdaregistry.info/termList/bookFormat/1001
+      :term: folio
+    - :id: http://rdaregistry.info/termList/bookFormat/1015
+      :uri: http://rdaregistry.info/termList/bookFormat/1015
+      :term: full-sheet

--- a/config/authorities/rda_broadcast_standard.yml
+++ b/config/authorities/rda_broadcast_standard.yml
@@ -1,0 +1,13 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/broadcastStand/1001
+      :uri: http://rdaregistry.info/termList/broadcastStand/1001
+      :term: HDTV
+    - :id: http://rdaregistry.info/termList/broadcastStand/1002
+      :uri: http://rdaregistry.info/termList/broadcastStand/1002
+      :term: NTSC
+    - :id: http://rdaregistry.info/termList/broadcastStand/1003
+      :uri: http://rdaregistry.info/termList/broadcastStand/1003
+      :term: PAL
+    - :id: http://rdaregistry.info/termList/broadcastStand/1004
+      :uri: http://rdaregistry.info/termList/broadcastStand/1004
+      :term: SECAM

--- a/config/authorities/rda_carrier_extent_unit.yml
+++ b/config/authorities/rda_carrier_extent_unit.yml
@@ -1,0 +1,124 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1001
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1001
+      :term: activity card
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1002
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1002
+      :term: atlas
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1003
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1003
+      :term: case
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1004
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1004
+      :term: chart
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1005
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1005
+      :term: coin
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1006
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1006
+      :term: collage
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1007
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1007
+      :term: column
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1008
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1008
+      :term: diagram
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1009
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1009
+      :term: diorama
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1010
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1010
+      :term: drawing
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1011
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1011
+      :term: exhibit
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1012
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1012
+      :term: flash card
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1013
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1013
+      :term: folded sheet
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1014
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1014
+      :term: game
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1015
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1015
+      :term: globe
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1016
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1016
+      :term: icon
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1017
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1017
+      :term: jigsaw puzzle
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1018
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1018
+      :term: leaf
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1019
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1019
+      :term: map
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1020
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1020
+      :term: medal
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1021
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1021
+      :term: mock-up
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1022
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1022
+      :term: model
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1023
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1023
+      :term: page
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1024
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1024
+      :term: painting
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1025
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1025
+      :term: photograph
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1026
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1026
+      :term: picture
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1027
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1027
+      :term: portfolio
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1028
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1028
+      :term: postcard
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1029
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1029
+      :term: poster
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1030
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1030
+      :term: print
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1031
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1031
+      :term: profile
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1032
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1032
+      :term: radiograph
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1033
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1033
+      :term: remote-sensing image
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1034
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1034
+      :term: sculpture
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1035
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1035
+      :term: section
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1036
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1036
+      :term: specimen
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1037
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1037
+      :term: study print
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1038
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1038
+      :term: technical drawing
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1039
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1039
+      :term: toy
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1040
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1040
+      :term: view
+    - :id: http://rdaregistry.info/termList/RDACarrierEU/1041
+      :uri: http://rdaregistry.info/termList/RDACarrierEU/1041
+      :term: wall chart

--- a/config/authorities/rda_carrier_type.yml
+++ b/config/authorities/rda_carrier_type.yml
@@ -1,0 +1,169 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1021
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1021
+      :term: aperture card
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1070
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1070
+      :term: audio belt
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1001
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1001
+      :term: Audio carriers (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1002
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1002
+      :term: audio cartridge
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1003
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1003
+      :term: audio cylinder
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1004
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1004
+      :term: audio disc
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1006
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1006
+      :term: audio roll
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1071
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1071
+      :term: audio wire reel
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1007
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1007
+      :term: audiocassette
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1008
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1008
+      :term: audiotape reel
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1045
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1045
+      :term: card
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1011
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1011
+      :term: computer card
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1010
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1010
+      :term: Computer carriers (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1012
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1012
+      :term: computer chip cartridge
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1013
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1013
+      :term: computer disc
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1014
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1014
+      :term: computer disc cartridge
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1015
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1015
+      :term: computer tape cartridge
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1016
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1016
+      :term: computer tape cassette
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1017
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1017
+      :term: computer tape reel
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1032
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1032
+      :term: film cartridge
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1033
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1033
+      :term: film cassette
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1034
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1034
+      :term: film reel
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1069
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1069
+      :term: film roll
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1035
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1035
+      :term: filmslip
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1036
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1036
+      :term: filmstrip
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1037
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1037
+      :term: filmstrip cartridge
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1046
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1046
+      :term: flipchart
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1022
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1022
+      :term: microfiche
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1023
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1023
+      :term: microfiche cassette
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1024
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1024
+      :term: microfilm cartridge
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1025
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1025
+      :term: microfilm cassette
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1026
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1026
+      :term: microfilm reel
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1056
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1056
+      :term: microfilm roll
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1027
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1027
+      :term: microfilm slip
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1020
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1020
+      :term: Microform carriers (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1028
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1028
+      :term: microopaque
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1030
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1030
+      :term: microscope slide
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1029
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1029
+      :term: Microscopic carriers (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1059
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1059
+      :term: object
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1018
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1018
+      :term: online resource
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1039
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1039
+      :term: overhead transparency
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1031
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1031
+      :term: Projected image carriers (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1047
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1047
+      :term: roll
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1048
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1048
+      :term: sheet
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1040
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1040
+      :term: slide
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1005
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1005
+      :term: sound-track reel
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1042
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1042
+      :term: stereograph card
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1043
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1043
+      :term: stereograph disc
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1041
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1041
+      :term: Stereographic carriers (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1044
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1044
+      :term: Unmediated carriers (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1050
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1050
+      :term: Video carriers (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1051
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1051
+      :term: video cartridge
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1052
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1052
+      :term: videocassette
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1060
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1060
+      :term: videodisc
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1053
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1053
+      :term: videotape reel
+    - :id: http://rdaregistry.info/termList/RDACarrierType/1049
+      :uri: http://rdaregistry.info/termList/RDACarrierType/1049
+      :term: volume

--- a/config/authorities/rda_cartographic_data_type.yml
+++ b/config/authorities/rda_cartographic_data_type.yml
@@ -1,0 +1,10 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDACartoDT/1003
+      :uri: http://rdaregistry.info/termList/RDACartoDT/1003
+      :term: point
+    - :id: http://rdaregistry.info/termList/RDACartoDT/1001
+      :uri: http://rdaregistry.info/termList/RDACartoDT/1001
+      :term: raster
+    - :id: http://rdaregistry.info/termList/RDACartoDT/1002
+      :uri: http://rdaregistry.info/termList/RDACartoDT/1002
+      :term: vector

--- a/config/authorities/rda_collection_accrual_method.yml
+++ b/config/authorities/rda_collection_accrual_method.yml
@@ -1,0 +1,16 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDACollectionAccrualMethod/1001
+      :uri: http://rdaregistry.info/termList/RDACollectionAccrualMethod/1001
+      :term: loan
+    - :id: http://rdaregistry.info/termList/RDACollectionAccrualMethod/1002
+      :uri: http://rdaregistry.info/termList/RDACollectionAccrualMethod/1002
+      :term: deposit
+    - :id: http://rdaregistry.info/termList/RDACollectionAccrualMethod/1003
+      :uri: http://rdaregistry.info/termList/RDACollectionAccrualMethod/1003
+      :term: donation
+    - :id: http://rdaregistry.info/termList/RDACollectionAccrualMethod/1004
+      :uri: http://rdaregistry.info/termList/RDACollectionAccrualMethod/1004
+      :term: license
+    - :id: http://rdaregistry.info/termList/RDACollectionAccrualMethod/1005
+      :uri: http://rdaregistry.info/termList/RDACollectionAccrualMethod/1005
+      :term: purchase

--- a/config/authorities/rda_collection_accrual_policy.yml
+++ b/config/authorities/rda_collection_accrual_policy.yml
@@ -1,0 +1,13 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1001
+      :uri: http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1001
+      :term: closed
+    - :id: http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1002
+      :uri: http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1002
+      :term: passive
+    - :id: http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1003
+      :uri: http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1003
+      :term: active
+    - :id: http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1004
+      :uri: http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1004
+      :term: selective

--- a/config/authorities/rda_colour_content.yml
+++ b/config/authorities/rda_colour_content.yml
@@ -1,0 +1,7 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDAColourContent/1002
+      :uri: http://rdaregistry.info/termList/RDAColourContent/1002
+      :term: monochrome
+    - :id: http://rdaregistry.info/termList/RDAColourContent/1003
+      :uri: http://rdaregistry.info/termList/RDAColourContent/1003
+      :term: polychrome

--- a/config/authorities/rda_configuration_of_playback_channels.yml
+++ b/config/authorities/rda_configuration_of_playback_channels.yml
@@ -1,0 +1,13 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/configPlayback/1001
+      :uri: http://rdaregistry.info/termList/configPlayback/1001
+      :term: mono
+    - :id: http://rdaregistry.info/termList/configPlayback/1003
+      :uri: http://rdaregistry.info/termList/configPlayback/1003
+      :term: quadraphonic
+    - :id: http://rdaregistry.info/termList/configPlayback/1002
+      :uri: http://rdaregistry.info/termList/configPlayback/1002
+      :term: stereo
+    - :id: http://rdaregistry.info/termList/configPlayback/1004
+      :uri: http://rdaregistry.info/termList/configPlayback/1004
+      :term: surround

--- a/config/authorities/rda_content_type.yml
+++ b/config/authorities/rda_content_type.yml
@@ -1,0 +1,73 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDAContentType/1001
+      :uri: http://rdaregistry.info/termList/RDAContentType/1001
+      :term: cartographic dataset
+    - :id: http://rdaregistry.info/termList/RDAContentType/1002
+      :uri: http://rdaregistry.info/termList/RDAContentType/1002
+      :term: cartographic image
+    - :id: http://rdaregistry.info/termList/RDAContentType/1003
+      :uri: http://rdaregistry.info/termList/RDAContentType/1003
+      :term: cartographic moving image
+    - :id: http://rdaregistry.info/termList/RDAContentType/1004
+      :uri: http://rdaregistry.info/termList/RDAContentType/1004
+      :term: cartographic tactile image
+    - :id: http://rdaregistry.info/termList/RDAContentType/1005
+      :uri: http://rdaregistry.info/termList/RDAContentType/1005
+      :term: cartographic tactile three-dimensional form
+    - :id: http://rdaregistry.info/termList/RDAContentType/1006
+      :uri: http://rdaregistry.info/termList/RDAContentType/1006
+      :term: cartographic three-dimensional form
+    - :id: http://rdaregistry.info/termList/RDAContentType/1007
+      :uri: http://rdaregistry.info/termList/RDAContentType/1007
+      :term: computer dataset
+    - :id: http://rdaregistry.info/termList/RDAContentType/1008
+      :uri: http://rdaregistry.info/termList/RDAContentType/1008
+      :term: computer program
+    - :id: http://rdaregistry.info/termList/RDAContentType/1009
+      :uri: http://rdaregistry.info/termList/RDAContentType/1009
+      :term: notated movement
+    - :id: http://rdaregistry.info/termList/RDAContentType/1010
+      :uri: http://rdaregistry.info/termList/RDAContentType/1010
+      :term: notated music
+    - :id: http://rdaregistry.info/termList/RDAContentType/1024
+      :uri: http://rdaregistry.info/termList/RDAContentType/1024
+      :term: performed movement
+    - :id: http://rdaregistry.info/termList/RDAContentType/1011
+      :uri: http://rdaregistry.info/termList/RDAContentType/1011
+      :term: performed music
+    - :id: http://rdaregistry.info/termList/RDAContentType/1012
+      :uri: http://rdaregistry.info/termList/RDAContentType/1012
+      :term: sounds
+    - :id: http://rdaregistry.info/termList/RDAContentType/1013
+      :uri: http://rdaregistry.info/termList/RDAContentType/1013
+      :term: spoken word
+    - :id: http://rdaregistry.info/termList/RDAContentType/1014
+      :uri: http://rdaregistry.info/termList/RDAContentType/1014
+      :term: still image
+    - :id: http://rdaregistry.info/termList/RDAContentType/1015
+      :uri: http://rdaregistry.info/termList/RDAContentType/1015
+      :term: tactile image
+    - :id: http://rdaregistry.info/termList/RDAContentType/1017
+      :uri: http://rdaregistry.info/termList/RDAContentType/1017
+      :term: tactile notated movement
+    - :id: http://rdaregistry.info/termList/RDAContentType/1016
+      :uri: http://rdaregistry.info/termList/RDAContentType/1016
+      :term: tactile notated music
+    - :id: http://rdaregistry.info/termList/RDAContentType/1018
+      :uri: http://rdaregistry.info/termList/RDAContentType/1018
+      :term: tactile text
+    - :id: http://rdaregistry.info/termList/RDAContentType/1019
+      :uri: http://rdaregistry.info/termList/RDAContentType/1019
+      :term: tactile three-dimensional form
+    - :id: http://rdaregistry.info/termList/RDAContentType/1020
+      :uri: http://rdaregistry.info/termList/RDAContentType/1020
+      :term: text
+    - :id: http://rdaregistry.info/termList/RDAContentType/1021
+      :uri: http://rdaregistry.info/termList/RDAContentType/1021
+      :term: three-dimensional form
+    - :id: http://rdaregistry.info/termList/RDAContentType/1022
+      :uri: http://rdaregistry.info/termList/RDAContentType/1022
+      :term: three-dimensional moving image
+    - :id: http://rdaregistry.info/termList/RDAContentType/1023
+      :uri: http://rdaregistry.info/termList/RDAContentType/1023
+      :term: two-dimensional moving image

--- a/config/authorities/rda_extension_plan.yml
+++ b/config/authorities/rda_extension_plan.yml
@@ -1,0 +1,16 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDAExtensionPlan/1002
+      :uri: http://rdaregistry.info/termList/RDAExtensionPlan/1002
+      :term: integrating determinate plan
+    - :id: http://rdaregistry.info/termList/RDAExtensionPlan/1003
+      :uri: http://rdaregistry.info/termList/RDAExtensionPlan/1003
+      :term: integrating indeterminate plan
+    - :id: http://rdaregistry.info/termList/RDAExtensionPlan/1001
+      :uri: http://rdaregistry.info/termList/RDAExtensionPlan/1001
+      :term: static plan
+    - :id: http://rdaregistry.info/termList/RDAExtensionPlan/1004
+      :uri: http://rdaregistry.info/termList/RDAExtensionPlan/1004
+      :term: successive determinate plan
+    - :id: http://rdaregistry.info/termList/RDAExtensionPlan/1005
+      :uri: http://rdaregistry.info/termList/RDAExtensionPlan/1005
+      :term: successive indeterminate plan

--- a/config/authorities/rda_file_type.yml
+++ b/config/authorities/rda_file_type.yml
@@ -1,0 +1,19 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/fileType/1001
+      :uri: http://rdaregistry.info/termList/fileType/1001
+      :term: audio file
+    - :id: http://rdaregistry.info/termList/fileType/1005
+      :uri: http://rdaregistry.info/termList/fileType/1005
+      :term: data file
+    - :id: http://rdaregistry.info/termList/fileType/1004
+      :uri: http://rdaregistry.info/termList/fileType/1004
+      :term: image file
+    - :id: http://rdaregistry.info/termList/fileType/1003
+      :uri: http://rdaregistry.info/termList/fileType/1003
+      :term: program file
+    - :id: http://rdaregistry.info/termList/fileType/1002
+      :uri: http://rdaregistry.info/termList/fileType/1002
+      :term: text file
+    - :id: http://rdaregistry.info/termList/fileType/1006
+      :uri: http://rdaregistry.info/termList/fileType/1006
+      :term: video file

--- a/config/authorities/rda_font_size.yml
+++ b/config/authorities/rda_font_size.yml
@@ -1,0 +1,10 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/fontSize/1001
+      :uri: http://rdaregistry.info/termList/fontSize/1001
+      :term: giant print
+    - :id: http://rdaregistry.info/termList/fontSize/1003
+      :uri: http://rdaregistry.info/termList/fontSize/1003
+      :term: jumbo braille
+    - :id: http://rdaregistry.info/termList/fontSize/1002
+      :uri: http://rdaregistry.info/termList/fontSize/1002
+      :term: large print

--- a/config/authorities/rda_form_of_musical_notation.yml
+++ b/config/authorities/rda_form_of_musical_notation.yml
@@ -1,0 +1,34 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/MusNotation/1001
+      :uri: http://rdaregistry.info/termList/MusNotation/1001
+      :term: graphic notation
+    - :id: http://rdaregistry.info/termList/MusNotation/1002
+      :uri: http://rdaregistry.info/termList/MusNotation/1002
+      :term: letter notation
+    - :id: http://rdaregistry.info/termList/MusNotation/1003
+      :uri: http://rdaregistry.info/termList/MusNotation/1003
+      :term: mensural notation
+    - :id: http://rdaregistry.info/termList/MusNotation/1010
+      :uri: http://rdaregistry.info/termList/MusNotation/1010
+      :term: neumatic notation
+    - :id: http://rdaregistry.info/termList/MusNotation/1004
+      :uri: http://rdaregistry.info/termList/MusNotation/1004
+      :term: number notation
+    - :id: http://rdaregistry.info/termList/MusNotation/1005
+      :uri: http://rdaregistry.info/termList/MusNotation/1005
+      :term: plainsong notation (Deprecated)
+    - :id: http://rdaregistry.info/termList/MusNotation/1006
+      :uri: http://rdaregistry.info/termList/MusNotation/1006
+      :term: solmization (Deprecated)
+    - :id: http://rdaregistry.info/termList/MusNotation/1007
+      :uri: http://rdaregistry.info/termList/MusNotation/1007
+      :term: staff notation
+    - :id: http://rdaregistry.info/termList/MusNotation/1011
+      :uri: http://rdaregistry.info/termList/MusNotation/1011
+      :term: syllabic notation
+    - :id: http://rdaregistry.info/termList/MusNotation/1008
+      :uri: http://rdaregistry.info/termList/MusNotation/1008
+      :term: tablature
+    - :id: http://rdaregistry.info/termList/MusNotation/1009
+      :uri: http://rdaregistry.info/termList/MusNotation/1009
+      :term: tonic sol-fa

--- a/config/authorities/rda_form_of_notated_movement.yml
+++ b/config/authorities/rda_form_of_notated_movement.yml
@@ -1,0 +1,28 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/noteMove/1009
+      :uri: http://rdaregistry.info/termList/noteMove/1009
+      :term: action stroke dance notation
+    - :id: http://rdaregistry.info/termList/noteMove/1008
+      :uri: http://rdaregistry.info/termList/noteMove/1008
+      :term: Beauchamp-Feuillet notation
+    - :id: http://rdaregistry.info/termList/noteMove/1007
+      :uri: http://rdaregistry.info/termList/noteMove/1007
+      :term: Benesh movement notation
+    - :id: http://rdaregistry.info/termList/noteMove/1006
+      :uri: http://rdaregistry.info/termList/noteMove/1006
+      :term: DanceWriting
+    - :id: http://rdaregistry.info/termList/noteMove/1005
+      :uri: http://rdaregistry.info/termList/noteMove/1005
+      :term: Eshkol-Wachman movement notation
+    - :id: http://rdaregistry.info/termList/noteMove/1004
+      :uri: http://rdaregistry.info/termList/noteMove/1004
+      :term: game play notation
+    - :id: http://rdaregistry.info/termList/noteMove/1010
+      :uri: http://rdaregistry.info/termList/noteMove/1010
+      :term: Kinetography Laban
+    - :id: http://rdaregistry.info/termList/noteMove/1002
+      :uri: http://rdaregistry.info/termList/noteMove/1002
+      :term: Labanotation
+    - :id: http://rdaregistry.info/termList/noteMove/1001
+      :uri: http://rdaregistry.info/termList/noteMove/1001
+      :term: Stepanov dance notation

--- a/config/authorities/rda_form_of_tactile_notation.yml
+++ b/config/authorities/rda_form_of_tactile_notation.yml
@@ -1,0 +1,22 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/TacNotation/1001
+      :uri: http://rdaregistry.info/termList/TacNotation/1001
+      :term: braille code
+    - :id: http://rdaregistry.info/termList/TacNotation/1002
+      :uri: http://rdaregistry.info/termList/TacNotation/1002
+      :term: computing braille code
+    - :id: http://rdaregistry.info/termList/TacNotation/1003
+      :uri: http://rdaregistry.info/termList/TacNotation/1003
+      :term: mathematics braille code
+    - :id: http://rdaregistry.info/termList/TacNotation/1004
+      :uri: http://rdaregistry.info/termList/TacNotation/1004
+      :term: Moon code
+    - :id: http://rdaregistry.info/termList/TacNotation/1005
+      :uri: http://rdaregistry.info/termList/TacNotation/1005
+      :term: music braille code
+    - :id: http://rdaregistry.info/termList/TacNotation/1007
+      :uri: http://rdaregistry.info/termList/TacNotation/1007
+      :term: tactile graphic
+    - :id: http://rdaregistry.info/termList/TacNotation/1006
+      :uri: http://rdaregistry.info/termList/TacNotation/1006
+      :term: tactile musical notation

--- a/config/authorities/rda_format_of_notated_music.yml
+++ b/config/authorities/rda_format_of_notated_music.yml
@@ -1,0 +1,34 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/formatNoteMus/1001
+      :uri: http://rdaregistry.info/termList/formatNoteMus/1001
+      :term: choir book
+    - :id: http://rdaregistry.info/termList/formatNoteMus/1002
+      :uri: http://rdaregistry.info/termList/formatNoteMus/1002
+      :term: chorus score
+    - :id: http://rdaregistry.info/termList/formatNoteMus/1003
+      :uri: http://rdaregistry.info/termList/formatNoteMus/1003
+      :term: condensed score
+    - :id: http://rdaregistry.info/termList/formatNoteMus/1004
+      :uri: http://rdaregistry.info/termList/formatNoteMus/1004
+      :term: part
+    - :id: http://rdaregistry.info/termList/formatNoteMus/1005
+      :uri: http://rdaregistry.info/termList/formatNoteMus/1005
+      :term: piano conductor part
+    - :id: http://rdaregistry.info/termList/formatNoteMus/1006
+      :uri: http://rdaregistry.info/termList/formatNoteMus/1006
+      :term: piano score
+    - :id: http://rdaregistry.info/termList/formatNoteMus/1007
+      :uri: http://rdaregistry.info/termList/formatNoteMus/1007
+      :term: score
+    - :id: http://rdaregistry.info/termList/formatNoteMus/1008
+      :uri: http://rdaregistry.info/termList/formatNoteMus/1008
+      :term: study score
+    - :id: http://rdaregistry.info/termList/formatNoteMus/1009
+      :uri: http://rdaregistry.info/termList/formatNoteMus/1009
+      :term: table book
+    - :id: http://rdaregistry.info/termList/formatNoteMus/1010
+      :uri: http://rdaregistry.info/termList/formatNoteMus/1010
+      :term: violin conductor part
+    - :id: http://rdaregistry.info/termList/formatNoteMus/1011
+      :uri: http://rdaregistry.info/termList/formatNoteMus/1011
+      :term: vocal score

--- a/config/authorities/rda_frequency.yml
+++ b/config/authorities/rda_frequency.yml
@@ -1,0 +1,49 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/frequency/1013
+      :uri: http://rdaregistry.info/termList/frequency/1013
+      :term: annual
+    - :id: http://rdaregistry.info/termList/frequency/1014
+      :uri: http://rdaregistry.info/termList/frequency/1014
+      :term: biennial
+    - :id: http://rdaregistry.info/termList/frequency/1007
+      :uri: http://rdaregistry.info/termList/frequency/1007
+      :term: bimonthly
+    - :id: http://rdaregistry.info/termList/frequency/1003
+      :uri: http://rdaregistry.info/termList/frequency/1003
+      :term: biweekly
+    - :id: http://rdaregistry.info/termList/frequency/1001
+      :uri: http://rdaregistry.info/termList/frequency/1001
+      :term: daily
+    - :id: http://rdaregistry.info/termList/frequency/1016
+      :uri: http://rdaregistry.info/termList/frequency/1016
+      :term: irregular
+    - :id: http://rdaregistry.info/termList/frequency/1008
+      :uri: http://rdaregistry.info/termList/frequency/1008
+      :term: monthly
+    - :id: http://rdaregistry.info/termList/frequency/1010
+      :uri: http://rdaregistry.info/termList/frequency/1010
+      :term: quarterly
+    - :id: http://rdaregistry.info/termList/frequency/1012
+      :uri: http://rdaregistry.info/termList/frequency/1012
+      :term: semiannual
+    - :id: http://rdaregistry.info/termList/frequency/1009
+      :uri: http://rdaregistry.info/termList/frequency/1009
+      :term: semimonthly
+    - :id: http://rdaregistry.info/termList/frequency/1005
+      :uri: http://rdaregistry.info/termList/frequency/1005
+      :term: semiweekly
+    - :id: http://rdaregistry.info/termList/frequency/1006
+      :uri: http://rdaregistry.info/termList/frequency/1006
+      :term: three times a month
+    - :id: http://rdaregistry.info/termList/frequency/1002
+      :uri: http://rdaregistry.info/termList/frequency/1002
+      :term: three times a week
+    - :id: http://rdaregistry.info/termList/frequency/1011
+      :uri: http://rdaregistry.info/termList/frequency/1011
+      :term: three times a year
+    - :id: http://rdaregistry.info/termList/frequency/1015
+      :uri: http://rdaregistry.info/termList/frequency/1015
+      :term: triennial
+    - :id: http://rdaregistry.info/termList/frequency/1004
+      :uri: http://rdaregistry.info/termList/frequency/1004
+      :term: weekly

--- a/config/authorities/rda_generation.yml
+++ b/config/authorities/rda_generation.yml
@@ -1,0 +1,58 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1001
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1001
+      :term: derivative master
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1002
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1002
+      :term: disc master
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1003
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1003
+      :term: duplicate (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1019
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1019
+      :term: duplicate negative
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1004
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1004
+      :term: first generation
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1005
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1005
+      :term: master
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1012
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1012
+      :term: master positive
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1006
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1006
+      :term: master tape
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1007
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1007
+      :term: mixed generation
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1008
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1008
+      :term: mother
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1009
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1009
+      :term: original
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1013
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1013
+      :term: original negative
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1010
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1010
+      :term: printing master
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1011
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1011
+      :term: reference print
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1014
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1014
+      :term: service copy
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1015
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1015
+      :term: stamper
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1016
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1016
+      :term: tape duplication master
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1017
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1017
+      :term: test pressing
+    - :id: http://rdaregistry.info/termList/RDAGeneration/1018
+      :uri: http://rdaregistry.info/termList/RDAGeneration/1018
+      :term: viewing copy

--- a/config/authorities/rda_groove_pitch_of_an_analog_cylinder.yml
+++ b/config/authorities/rda_groove_pitch_of_an_analog_cylinder.yml
@@ -1,0 +1,7 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/groovePitch/1005
+      :uri: http://rdaregistry.info/termList/groovePitch/1005
+      :term: fine
+    - :id: http://rdaregistry.info/termList/groovePitch/1006
+      :uri: http://rdaregistry.info/termList/groovePitch/1006
+      :term: standard

--- a/config/authorities/rda_groove_width_of_an_analog_disc.yml
+++ b/config/authorities/rda_groove_width_of_an_analog_disc.yml
@@ -1,0 +1,7 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/grooveWidth/1001
+      :uri: http://rdaregistry.info/termList/grooveWidth/1001
+      :term: coarse groove
+    - :id: http://rdaregistry.info/termList/grooveWidth/1002
+      :uri: http://rdaregistry.info/termList/grooveWidth/1002
+      :term: microgroove

--- a/config/authorities/rda_illustrative_content.yml
+++ b/config/authorities/rda_illustrative_content.yml
@@ -1,0 +1,46 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/IllusContent/1001
+      :uri: http://rdaregistry.info/termList/IllusContent/1001
+      :term: coat of arms
+    - :id: http://rdaregistry.info/termList/IllusContent/1002
+      :uri: http://rdaregistry.info/termList/IllusContent/1002
+      :term: facsimile
+    - :id: http://rdaregistry.info/termList/IllusContent/1003
+      :uri: http://rdaregistry.info/termList/IllusContent/1003
+      :term: form
+    - :id: http://rdaregistry.info/termList/IllusContent/1004
+      :uri: http://rdaregistry.info/termList/IllusContent/1004
+      :term: genealogical table
+    - :id: http://rdaregistry.info/termList/IllusContent/1005
+      :uri: http://rdaregistry.info/termList/IllusContent/1005
+      :term: graph
+    - :id: http://rdaregistry.info/termList/IllusContent/1006
+      :uri: http://rdaregistry.info/termList/IllusContent/1006
+      :term: illumination
+    - :id: http://rdaregistry.info/termList/IllusContent/1007
+      :uri: http://rdaregistry.info/termList/IllusContent/1007
+      :term: Illuminations (Deprecated)
+    - :id: http://rdaregistry.info/termList/IllusContent/1014
+      :uri: http://rdaregistry.info/termList/IllusContent/1014
+      :term: illustration
+    - :id: http://rdaregistry.info/termList/IllusContent/1015
+      :uri: http://rdaregistry.info/termList/IllusContent/1015
+      :term: Illustrations (Deprecated)
+    - :id: http://rdaregistry.info/termList/IllusContent/1008
+      :uri: http://rdaregistry.info/termList/IllusContent/1008
+      :term: map
+    - :id: http://rdaregistry.info/termList/IllusContent/1009
+      :uri: http://rdaregistry.info/termList/IllusContent/1009
+      :term: Music (Deprecated)
+    - :id: http://rdaregistry.info/termList/IllusContent/1010
+      :uri: http://rdaregistry.info/termList/IllusContent/1010
+      :term: photograph
+    - :id: http://rdaregistry.info/termList/IllusContent/1011
+      :uri: http://rdaregistry.info/termList/IllusContent/1011
+      :term: plan
+    - :id: http://rdaregistry.info/termList/IllusContent/1012
+      :uri: http://rdaregistry.info/termList/IllusContent/1012
+      :term: portrait
+    - :id: http://rdaregistry.info/termList/IllusContent/1013
+      :uri: http://rdaregistry.info/termList/IllusContent/1013
+      :term: sample

--- a/config/authorities/rda_interactivity_mode.yml
+++ b/config/authorities/rda_interactivity_mode.yml
@@ -1,0 +1,7 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDAInteractivityMode/1001
+      :uri: http://rdaregistry.info/termList/RDAInteractivityMode/1001
+      :term: interactive
+    - :id: http://rdaregistry.info/termList/RDAInteractivityMode/1002
+      :uri: http://rdaregistry.info/termList/RDAInteractivityMode/1002
+      :term: non-interactive

--- a/config/authorities/rda_layout.yml
+++ b/config/authorities/rda_layout.yml
@@ -1,0 +1,52 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/layout/1003
+      :uri: http://rdaregistry.info/termList/layout/1003
+      :term: back to back
+    - :id: http://rdaregistry.info/termList/layout/1004
+      :uri: http://rdaregistry.info/termList/layout/1004
+      :term: bar by bar
+    - :id: http://rdaregistry.info/termList/layout/1005
+      :uri: http://rdaregistry.info/termList/layout/1005
+      :term: bar over bar
+    - :id: http://rdaregistry.info/termList/layout/1006
+      :uri: http://rdaregistry.info/termList/layout/1006
+      :term: both sides
+    - :id: http://rdaregistry.info/termList/layout/1017
+      :uri: http://rdaregistry.info/termList/layout/1017
+      :term: double line spacing
+    - :id: http://rdaregistry.info/termList/layout/1001
+      :uri: http://rdaregistry.info/termList/layout/1001
+      :term: double sided
+    - :id: http://rdaregistry.info/termList/layout/1007
+      :uri: http://rdaregistry.info/termList/layout/1007
+      :term: line by line
+    - :id: http://rdaregistry.info/termList/layout/1008
+      :uri: http://rdaregistry.info/termList/layout/1008
+      :term: line over line
+    - :id: http://rdaregistry.info/termList/layout/1009
+      :uri: http://rdaregistry.info/termList/layout/1009
+      :term: melody chord system
+    - :id: http://rdaregistry.info/termList/layout/1010
+      :uri: http://rdaregistry.info/termList/layout/1010
+      :term: open score
+    - :id: http://rdaregistry.info/termList/layout/1011
+      :uri: http://rdaregistry.info/termList/layout/1011
+      :term: outline
+    - :id: http://rdaregistry.info/termList/layout/1012
+      :uri: http://rdaregistry.info/termList/layout/1012
+      :term: paragraph
+    - :id: http://rdaregistry.info/termList/layout/1013
+      :uri: http://rdaregistry.info/termList/layout/1013
+      :term: section by section
+    - :id: http://rdaregistry.info/termList/layout/1014
+      :uri: http://rdaregistry.info/termList/layout/1014
+      :term: short form scoring
+    - :id: http://rdaregistry.info/termList/layout/1015
+      :uri: http://rdaregistry.info/termList/layout/1015
+      :term: single line
+    - :id: http://rdaregistry.info/termList/layout/1002
+      :uri: http://rdaregistry.info/termList/layout/1002
+      :term: single sided
+    - :id: http://rdaregistry.info/termList/layout/1016
+      :uri: http://rdaregistry.info/termList/layout/1016
+      :term: vertical score

--- a/config/authorities/rda_linked_data_work.yml
+++ b/config/authorities/rda_linked_data_work.yml
@@ -1,0 +1,10 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDALinkedDataWork/1003
+      :uri: http://rdaregistry.info/termList/RDALinkedDataWork/1003
+      :term: element set
+    - :id: http://rdaregistry.info/termList/RDALinkedDataWork/1002
+      :uri: http://rdaregistry.info/termList/RDALinkedDataWork/1002
+      :term: value vocabulary
+    - :id: http://rdaregistry.info/termList/RDALinkedDataWork/1001
+      :uri: http://rdaregistry.info/termList/RDALinkedDataWork/1001
+      :term: dataset

--- a/config/authorities/rda_material.yml
+++ b/config/authorities/rda_material.yml
@@ -1,0 +1,145 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1001
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1001
+      :term: acetate
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1002
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1002
+      :term: acrylic paint
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1003
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1003
+      :term: aluminium
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1004
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1004
+      :term: Bristol board
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1005
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1005
+      :term: canvas
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1006
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1006
+      :term: cardboard
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1007
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1007
+      :term: ceramic
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1008
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1008
+      :term: chalk
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1009
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1009
+      :term: charcoal
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1010
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1010
+      :term: diacetate
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1046
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1046
+      :term: diazo emulsion
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1011
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1011
+      :term: dye
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1012
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1012
+      :term: glass
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1013
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1013
+      :term: gouache
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1014
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1014
+      :term: graphite
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1015
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1015
+      :term: hardboard
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1016
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1016
+      :term: illustration board
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1017
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1017
+      :term: ink
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1018
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1018
+      :term: ivory
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1019
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1019
+      :term: lacquer
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1020
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1020
+      :term: leather
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1021
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1021
+      :term: magnetic particles
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1022
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1022
+      :term: metal
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1023
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1023
+      :term: nitrate
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1024
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1024
+      :term: oil paint
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1025
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1025
+      :term: paper
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1026
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1026
+      :term: parchment
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1027
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1027
+      :term: pastel
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1028
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1028
+      :term: plaster
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1029
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1029
+      :term: plastic
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1030
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1030
+      :term: polyester
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1031
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1031
+      :term: porcelain
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1032
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1032
+      :term: rubber
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1033
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1033
+      :term: safety base
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1034
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1034
+      :term: shellac
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1047
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1047
+      :term: silver halide emulsion
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1035
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1035
+      :term: skin
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1036
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1036
+      :term: stone
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1037
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1037
+      :term: synthetic
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1038
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1038
+      :term: tempera
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1039
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1039
+      :term: textile
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1040
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1040
+      :term: triacetate
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1041
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1041
+      :term: vellum
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1048
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1048
+      :term: vesicular emulsion
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1042
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1042
+      :term: vinyl
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1043
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1043
+      :term: watercolour
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1044
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1044
+      :term: wax
+    - :id: http://rdaregistry.info/termList/RDAMaterial/1045
+      :uri: http://rdaregistry.info/termList/RDAMaterial/1045
+      :term: wood

--- a/config/authorities/rda_media_type.yml
+++ b/config/authorities/rda_media_type.yml
@@ -1,0 +1,25 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDAMediaType/1001
+      :uri: http://rdaregistry.info/termList/RDAMediaType/1001
+      :term: audio
+    - :id: http://rdaregistry.info/termList/RDAMediaType/1003
+      :uri: http://rdaregistry.info/termList/RDAMediaType/1003
+      :term: computer
+    - :id: http://rdaregistry.info/termList/RDAMediaType/1002
+      :uri: http://rdaregistry.info/termList/RDAMediaType/1002
+      :term: microform
+    - :id: http://rdaregistry.info/termList/RDAMediaType/1004
+      :uri: http://rdaregistry.info/termList/RDAMediaType/1004
+      :term: microscopic
+    - :id: http://rdaregistry.info/termList/RDAMediaType/1005
+      :uri: http://rdaregistry.info/termList/RDAMediaType/1005
+      :term: projected
+    - :id: http://rdaregistry.info/termList/RDAMediaType/1006
+      :uri: http://rdaregistry.info/termList/RDAMediaType/1006
+      :term: stereographic
+    - :id: http://rdaregistry.info/termList/RDAMediaType/1007
+      :uri: http://rdaregistry.info/termList/RDAMediaType/1007
+      :term: unmediated
+    - :id: http://rdaregistry.info/termList/RDAMediaType/1008
+      :uri: http://rdaregistry.info/termList/RDAMediaType/1008
+      :term: video

--- a/config/authorities/rda_mode_of_issuance.yml
+++ b/config/authorities/rda_mode_of_issuance.yml
@@ -1,0 +1,16 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/ModeIssue/1004
+      :uri: http://rdaregistry.info/termList/ModeIssue/1004
+      :term: integrating resource (Deprecated)
+    - :id: http://rdaregistry.info/termList/ModeIssue/1002
+      :uri: http://rdaregistry.info/termList/ModeIssue/1002
+      :term: multipart monograph (Deprecated)
+    - :id: http://rdaregistry.info/termList/ModeIssue/1005
+      :uri: http://rdaregistry.info/termList/ModeIssue/1005
+      :term: multiple unit
+    - :id: http://rdaregistry.info/termList/ModeIssue/1003
+      :uri: http://rdaregistry.info/termList/ModeIssue/1003
+      :term: serial (Deprecated)
+    - :id: http://rdaregistry.info/termList/ModeIssue/1001
+      :uri: http://rdaregistry.info/termList/ModeIssue/1001
+      :term: single unit

--- a/config/authorities/rda_polarity.yml
+++ b/config/authorities/rda_polarity.yml
@@ -1,0 +1,10 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDAPolarity/1003
+      :uri: http://rdaregistry.info/termList/RDAPolarity/1003
+      :term: mixed polarity
+    - :id: http://rdaregistry.info/termList/RDAPolarity/1002
+      :uri: http://rdaregistry.info/termList/RDAPolarity/1002
+      :term: negative
+    - :id: http://rdaregistry.info/termList/RDAPolarity/1001
+      :uri: http://rdaregistry.info/termList/RDAPolarity/1001
+      :term: positive

--- a/config/authorities/rda_presentation_format.yml
+++ b/config/authorities/rda_presentation_format.yml
@@ -1,0 +1,37 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/presFormat/1012
+      :uri: http://rdaregistry.info/termList/presFormat/1012
+      :term: 3D
+    - :id: http://rdaregistry.info/termList/presFormat/1002
+      :uri: http://rdaregistry.info/termList/presFormat/1002
+      :term: Cinemiracle
+    - :id: http://rdaregistry.info/termList/presFormat/1001
+      :uri: http://rdaregistry.info/termList/presFormat/1001
+      :term: Cinerama
+    - :id: http://rdaregistry.info/termList/presFormat/1003
+      :uri: http://rdaregistry.info/termList/presFormat/1003
+      :term: Circarama
+    - :id: http://rdaregistry.info/termList/presFormat/1004
+      :uri: http://rdaregistry.info/termList/presFormat/1004
+      :term: IMAX
+    - :id: http://rdaregistry.info/termList/presFormat/1005
+      :uri: http://rdaregistry.info/termList/presFormat/1005
+      :term: multiprojector
+    - :id: http://rdaregistry.info/termList/presFormat/1006
+      :uri: http://rdaregistry.info/termList/presFormat/1006
+      :term: multiscreen
+    - :id: http://rdaregistry.info/termList/presFormat/1007
+      :uri: http://rdaregistry.info/termList/presFormat/1007
+      :term: Panavision
+    - :id: http://rdaregistry.info/termList/presFormat/1008
+      :uri: http://rdaregistry.info/termList/presFormat/1008
+      :term: standard silent aperture
+    - :id: http://rdaregistry.info/termList/presFormat/1009
+      :uri: http://rdaregistry.info/termList/presFormat/1009
+      :term: standard sound aperture
+    - :id: http://rdaregistry.info/termList/presFormat/1010
+      :uri: http://rdaregistry.info/termList/presFormat/1010
+      :term: stereoscopic
+    - :id: http://rdaregistry.info/termList/presFormat/1011
+      :uri: http://rdaregistry.info/termList/presFormat/1011
+      :term: Techniscope

--- a/config/authorities/rda_production_method.yml
+++ b/config/authorities/rda_production_method.yml
@@ -1,0 +1,61 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1001
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1001
+      :term: blueline process
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1002
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1002
+      :term: blueprint process
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1015
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1015
+      :term: burning
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1003
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1003
+      :term: collotype
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1004
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1004
+      :term: daguerreotype process
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1018
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1018
+      :term: embossing
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1005
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1005
+      :term: engraving
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1006
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1006
+      :term: etching
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1016
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1016
+      :term: inscribing
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1007
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1007
+      :term: lithography
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1008
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1008
+      :term: photocopying
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1009
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1009
+      :term: photoengraving
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1014
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1014
+      :term: photogravure process
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1010
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1010
+      :term: printing
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1019
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1019
+      :term: solid dot
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1017
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1017
+      :term: stamping
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1020
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1020
+      :term: swell paper
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1021
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1021
+      :term: thermoform
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1011
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1011
+      :term: white print process
+    - :id: http://rdaregistry.info/termList/RDAproductionMethod/1012
+      :uri: http://rdaregistry.info/termList/RDAproductionMethod/1012
+      :term: woodcut making

--- a/config/authorities/rda_recording_medium.yml
+++ b/config/authorities/rda_recording_medium.yml
@@ -1,0 +1,10 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/recMedium/1001
+      :uri: http://rdaregistry.info/termList/recMedium/1001
+      :term: magnetic
+    - :id: http://rdaregistry.info/termList/recMedium/1002
+      :uri: http://rdaregistry.info/termList/recMedium/1002
+      :term: magneto-optical
+    - :id: http://rdaregistry.info/termList/recMedium/1003
+      :uri: http://rdaregistry.info/termList/recMedium/1003
+      :term: optical

--- a/config/authorities/rda_recording_methods.yml
+++ b/config/authorities/rda_recording_methods.yml
@@ -1,0 +1,13 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDARecordingMethods/1003
+      :uri: http://rdaregistry.info/termList/RDARecordingMethods/1003
+      :term: identifier
+    - :id: http://rdaregistry.info/termList/RDARecordingMethods/1004
+      :uri: http://rdaregistry.info/termList/RDARecordingMethods/1004
+      :term: IRI
+    - :id: http://rdaregistry.info/termList/RDARecordingMethods/1002
+      :uri: http://rdaregistry.info/termList/RDARecordingMethods/1002
+      :term: structured description
+    - :id: http://rdaregistry.info/termList/RDARecordingMethods/1001
+      :uri: http://rdaregistry.info/termList/RDARecordingMethods/1001
+      :term: unstructured description

--- a/config/authorities/rda_recording_source.yml
+++ b/config/authorities/rda_recording_source.yml
@@ -1,0 +1,40 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1011
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1011
+      :term: caption
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1001
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1001
+      :term: container
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1008
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1008
+      :term: cover
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1012
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1012
+      :term: embedded metadata
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1009
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1009
+      :term: jacket
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1007
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1007
+      :term: carrier label
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1010
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1010
+      :term: masthead
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1013
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1013
+      :term: series title page
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1006
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1006
+      :term: title card
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1002
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1002
+      :term: title frame
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1003
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1003
+      :term: title page
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1004
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1004
+      :term: title screen
+    - :id: http://rdaregistry.info/termList/RDARecordingSources/1005
+      :uri: http://rdaregistry.info/termList/RDARecordingSources/1005
+      :term: title sheet

--- a/config/authorities/rda_reduction_ratio_designation.yml
+++ b/config/authorities/rda_reduction_ratio_designation.yml
@@ -1,0 +1,16 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDAReductionRatio/1003
+      :uri: http://rdaregistry.info/termList/RDAReductionRatio/1003
+      :term: high reduction
+    - :id: http://rdaregistry.info/termList/RDAReductionRatio/1001
+      :uri: http://rdaregistry.info/termList/RDAReductionRatio/1001
+      :term: low reduction
+    - :id: http://rdaregistry.info/termList/RDAReductionRatio/1002
+      :uri: http://rdaregistry.info/termList/RDAReductionRatio/1002
+      :term: normal reduction
+    - :id: http://rdaregistry.info/termList/RDAReductionRatio/1005
+      :uri: http://rdaregistry.info/termList/RDAReductionRatio/1005
+      :term: ultra high reduction
+    - :id: http://rdaregistry.info/termList/RDAReductionRatio/1004
+      :uri: http://rdaregistry.info/termList/RDAReductionRatio/1004
+      :term: very high reduction

--- a/config/authorities/rda_regional_encoding.yml
+++ b/config/authorities/rda_regional_encoding.yml
@@ -1,0 +1,46 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1001
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1001
+      :term: all regions
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1002
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1002
+      :term: Region 1
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1004
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1004
+      :term: Region 2
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1008
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1008
+      :term: Region 3
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1010
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1010
+      :term: Region 4
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1011
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1011
+      :term: Region 5
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1015
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1015
+      :term: Region 6
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1007
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1007
+      :term: Region 7
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1006
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1006
+      :term: Region 8
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1003
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1003
+      :term: Region A
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1005
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1005
+      :term: Region B
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1012
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1012
+      :term: Region C (Blu-ray)
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1009
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1009
+      :term: Region C (video game)
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1013
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1013
+      :term: Region J
+    - :id: http://rdaregistry.info/termList/RDARegionalEncoding/1014
+      :uri: http://rdaregistry.info/termList/RDARegionalEncoding/1014
+      :term: Region U/C

--- a/config/authorities/rda_scale_designation.yml
+++ b/config/authorities/rda_scale_designation.yml
@@ -1,0 +1,13 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/scale/1004
+      :uri: http://rdaregistry.info/termList/scale/1004
+      :term: not drawn to scale
+    - :id: http://rdaregistry.info/termList/scale/1002
+      :uri: http://rdaregistry.info/termList/scale/1002
+      :term: scale not given
+    - :id: http://rdaregistry.info/termList/scale/1003
+      :uri: http://rdaregistry.info/termList/scale/1003
+      :term: scale varies
+    - :id: http://rdaregistry.info/termList/scale/1001
+      :uri: http://rdaregistry.info/termList/scale/1001
+      :term: scales differ

--- a/config/authorities/rda_sound_content.yml
+++ b/config/authorities/rda_sound_content.yml
@@ -1,0 +1,7 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/soundCont/1002
+      :uri: http://rdaregistry.info/termList/soundCont/1002
+      :term: silent
+    - :id: http://rdaregistry.info/termList/soundCont/1001
+      :uri: http://rdaregistry.info/termList/soundCont/1001
+      :term: sound

--- a/config/authorities/rda_special_playback_characteristics.yml
+++ b/config/authorities/rda_special_playback_characteristics.yml
@@ -1,0 +1,28 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/specPlayback/1001
+      :uri: http://rdaregistry.info/termList/specPlayback/1001
+      :term: CCIR encoded
+    - :id: http://rdaregistry.info/termList/specPlayback/1002
+      :uri: http://rdaregistry.info/termList/specPlayback/1002
+      :term: CX encoded
+    - :id: http://rdaregistry.info/termList/specPlayback/1003
+      :uri: http://rdaregistry.info/termList/specPlayback/1003
+      :term: dbx encoded
+    - :id: http://rdaregistry.info/termList/specPlayback/1004
+      :uri: http://rdaregistry.info/termList/specPlayback/1004
+      :term: Dolby
+    - :id: http://rdaregistry.info/termList/specPlayback/1005
+      :uri: http://rdaregistry.info/termList/specPlayback/1005
+      :term: Dolby-A encoded
+    - :id: http://rdaregistry.info/termList/specPlayback/1006
+      :uri: http://rdaregistry.info/termList/specPlayback/1006
+      :term: Dolby-B encoded
+    - :id: http://rdaregistry.info/termList/specPlayback/1007
+      :uri: http://rdaregistry.info/termList/specPlayback/1007
+      :term: Dolby-C encoded
+    - :id: http://rdaregistry.info/termList/specPlayback/1008
+      :uri: http://rdaregistry.info/termList/specPlayback/1008
+      :term: LPCM
+    - :id: http://rdaregistry.info/termList/specPlayback/1009
+      :uri: http://rdaregistry.info/termList/specPlayback/1009
+      :term: NAB standard

--- a/config/authorities/rda_status_of_identification.yml
+++ b/config/authorities/rda_status_of_identification.yml
@@ -1,0 +1,10 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/statIdentification/1001
+      :uri: http://rdaregistry.info/termList/statIdentification/1001
+      :term: fully established
+    - :id: http://rdaregistry.info/termList/statIdentification/1003
+      :uri: http://rdaregistry.info/termList/statIdentification/1003
+      :term: preliminary
+    - :id: http://rdaregistry.info/termList/statIdentification/1002
+      :uri: http://rdaregistry.info/termList/statIdentification/1002
+      :term: provisional

--- a/config/authorities/rda_terms.yml
+++ b/config/authorities/rda_terms.yml
@@ -1,0 +1,640 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDATerms/1001
+      :uri: http://rdaregistry.info/termList/RDATerms/1001
+      :term: access point
+    - :id: http://rdaregistry.info/termList/RDATerms/1002
+      :uri: http://rdaregistry.info/termList/RDATerms/1002
+      :term: accessible labels
+    - :id: http://rdaregistry.info/termList/RDATerms/1003
+      :uri: http://rdaregistry.info/termList/RDATerms/1003
+      :term: adaptation
+    - :id: http://rdaregistry.info/termList/RDATerms/1004
+      :uri: http://rdaregistry.info/termList/RDATerms/1004
+      :term: added title page (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1125
+      :uri: http://rdaregistry.info/termList/RDATerms/1125
+      :term: aggregate
+    - :id: http://rdaregistry.info/termList/RDATerms/1126
+      :uri: http://rdaregistry.info/termList/RDATerms/1126
+      :term: aggregating expression
+    - :id: http://rdaregistry.info/termList/RDATerms/1127
+      :uri: http://rdaregistry.info/termList/RDATerms/1127
+      :term: aggregating work
+    - :id: http://rdaregistry.info/termList/RDATerms/1180
+      :uri: http://rdaregistry.info/termList/RDATerms/1180
+      :term: alignment
+    - :id: http://rdaregistry.info/termList/RDATerms/1005
+      :uri: http://rdaregistry.info/termList/RDATerms/1005
+      :term: alternative title
+    - :id: http://rdaregistry.info/termList/RDATerms/1152
+      :uri: http://rdaregistry.info/termList/RDATerms/1152
+      :term: amalgamation
+    - :id: http://rdaregistry.info/termList/RDATerms/1006
+      :uri: http://rdaregistry.info/termList/RDATerms/1006
+      :term: analytical description (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1128
+      :uri: http://rdaregistry.info/termList/RDATerms/1128
+      :term: appellation element
+    - :id: http://rdaregistry.info/termList/RDATerms/1155
+      :uri: http://rdaregistry.info/termList/RDATerms/1155
+      :term: application profile
+    - :id: http://rdaregistry.info/termList/RDATerms/1007
+      :uri: http://rdaregistry.info/termList/RDATerms/1007
+      :term: archival resource
+    - :id: http://rdaregistry.info/termList/RDATerms/1008
+      :uri: http://rdaregistry.info/termList/RDATerms/1008
+      :term: arrangement
+    - :id: http://rdaregistry.info/termList/RDATerms/1108
+      :uri: http://rdaregistry.info/termList/RDATerms/1108
+      :term: attribute element
+    - :id: http://rdaregistry.info/termList/RDATerms/1009
+      :uri: http://rdaregistry.info/termList/RDATerms/1009
+      :term: audio description
+    - :id: http://rdaregistry.info/termList/RDATerms/1010
+      :uri: http://rdaregistry.info/termList/RDATerms/1010
+      :term: audio recording
+    - :id: http://rdaregistry.info/termList/RDATerms/1011
+      :uri: http://rdaregistry.info/termList/RDATerms/1011
+      :term: audiotape
+    - :id: http://rdaregistry.info/termList/RDATerms/1168
+      :uri: http://rdaregistry.info/termList/RDATerms/1168
+      :term: augmentation aggregate
+    - :id: http://rdaregistry.info/termList/RDATerms/1150
+      :uri: http://rdaregistry.info/termList/RDATerms/1150
+      :term: augmented work
+    - :id: http://rdaregistry.info/termList/RDATerms/1129
+      :uri: http://rdaregistry.info/termList/RDATerms/1129
+      :term: augmenting work
+    - :id: http://rdaregistry.info/termList/RDATerms/1012
+      :uri: http://rdaregistry.info/termList/RDATerms/1012
+      :term: authorized access point
+    - :id: http://rdaregistry.info/termList/RDATerms/1013
+      :uri: http://rdaregistry.info/termList/RDATerms/1013
+      :term: binding
+    - :id: http://rdaregistry.info/termList/RDATerms/1014
+      :uri: http://rdaregistry.info/termList/RDATerms/1014
+      :term: caption title
+    - :id: http://rdaregistry.info/termList/RDATerms/1015
+      :uri: http://rdaregistry.info/termList/RDATerms/1015
+      :term: captioning
+    - :id: http://rdaregistry.info/termList/RDATerms/1154
+      :uri: http://rdaregistry.info/termList/RDATerms/1154
+      :term: cardinality restriction
+    - :id: http://rdaregistry.info/termList/RDATerms/1016
+      :uri: http://rdaregistry.info/termList/RDATerms/1016
+      :term: carrier
+    - :id: http://rdaregistry.info/termList/RDATerms/1017
+      :uri: http://rdaregistry.info/termList/RDATerms/1017
+      :term: cartographic content
+    - :id: http://rdaregistry.info/termList/RDATerms/1119
+      :uri: http://rdaregistry.info/termList/RDATerms/1119
+      :term: cartographic work
+    - :id: http://rdaregistry.info/termList/RDATerms/1117
+      :uri: http://rdaregistry.info/termList/RDATerms/1117
+      :term: choreographic work
+    - :id: http://rdaregistry.info/termList/RDATerms/1018
+      :uri: http://rdaregistry.info/termList/RDATerms/1018
+      :term: citation title of a legal work
+    - :id: http://rdaregistry.info/termList/RDATerms/1177
+      :uri: http://rdaregistry.info/termList/RDATerms/1177
+      :term: class
+    - :id: http://rdaregistry.info/termList/RDATerms/1130
+      :uri: http://rdaregistry.info/termList/RDATerms/1130
+      :term: coherent description
+    - :id: http://rdaregistry.info/termList/RDATerms/1019
+      :uri: http://rdaregistry.info/termList/RDATerms/1019
+      :term: collection
+    - :id: http://rdaregistry.info/termList/RDATerms/1167
+      :uri: http://rdaregistry.info/termList/RDATerms/1167
+      :term: collection aggregate
+    - :id: http://rdaregistry.info/termList/RDATerms/1020
+      :uri: http://rdaregistry.info/termList/RDATerms/1020
+      :term: collective title
+    - :id: http://rdaregistry.info/termList/RDATerms/1176
+      :uri: http://rdaregistry.info/termList/RDATerms/1176
+      :term: common title
+    - :id: http://rdaregistry.info/termList/RDATerms/1021
+      :uri: http://rdaregistry.info/termList/RDATerms/1021
+      :term: component part (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1022
+      :uri: http://rdaregistry.info/termList/RDATerms/1022
+      :term: composite description (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1023
+      :uri: http://rdaregistry.info/termList/RDATerms/1023
+      :term: compound surname
+    - :id: http://rdaregistry.info/termList/RDATerms/1024
+      :uri: http://rdaregistry.info/termList/RDATerms/1024
+      :term: comprehensive description (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1174
+      :uri: http://rdaregistry.info/termList/RDATerms/1174
+      :term: computer content
+    - :id: http://rdaregistry.info/termList/RDATerms/1181
+      :uri: http://rdaregistry.info/termList/RDATerms/1181
+      :term: conceptual model
+    - :id: http://rdaregistry.info/termList/RDATerms/1025
+      :uri: http://rdaregistry.info/termList/RDATerms/1025
+      :term: conference
+    - :id: http://rdaregistry.info/termList/RDATerms/1026
+      :uri: http://rdaregistry.info/termList/RDATerms/1026
+      :term: container
+    - :id: http://rdaregistry.info/termList/RDATerms/1121
+      :uri: http://rdaregistry.info/termList/RDATerms/1121
+      :term: content
+    - :id: http://rdaregistry.info/termList/RDATerms/1147
+      :uri: http://rdaregistry.info/termList/RDATerms/1147
+      :term: content standard
+    - :id: http://rdaregistry.info/termList/RDATerms/1027
+      :uri: http://rdaregistry.info/termList/RDATerms/1027
+      :term: conventional collective title
+    - :id: http://rdaregistry.info/termList/RDATerms/1028
+      :uri: http://rdaregistry.info/termList/RDATerms/1028
+      :term: conventional name
+    - :id: http://rdaregistry.info/termList/RDATerms/1029
+      :uri: http://rdaregistry.info/termList/RDATerms/1029
+      :term: core (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1030
+      :uri: http://rdaregistry.info/termList/RDATerms/1030
+      :term: cover (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1142
+      :uri: http://rdaregistry.info/termList/RDATerms/1142
+      :term: data provenance
+    - :id: http://rdaregistry.info/termList/RDATerms/1031
+      :uri: http://rdaregistry.info/termList/RDATerms/1031
+      :term: dataset (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1032
+      :uri: http://rdaregistry.info/termList/RDATerms/1032
+      :term: date of a treaty
+    - :id: http://rdaregistry.info/termList/RDATerms/1033
+      :uri: http://rdaregistry.info/termList/RDATerms/1033
+      :term: date of promulgation of a law, etc.
+    - :id: http://rdaregistry.info/termList/RDATerms/1035
+      :uri: http://rdaregistry.info/termList/RDATerms/1035
+      :term: description
+    - :id: http://rdaregistry.info/termList/RDATerms/1034
+      :uri: http://rdaregistry.info/termList/RDATerms/1034
+      :term: designation
+    - :id: http://rdaregistry.info/termList/RDATerms/1036
+      :uri: http://rdaregistry.info/termList/RDATerms/1036
+      :term: devised title
+    - :id: http://rdaregistry.info/termList/RDATerms/1131
+      :uri: http://rdaregistry.info/termList/RDATerms/1131
+      :term: diachronic work
+    - :id: http://rdaregistry.info/termList/RDATerms/1132
+      :uri: http://rdaregistry.info/termList/RDATerms/1132
+      :term: diacritic mark
+    - :id: http://rdaregistry.info/termList/RDATerms/1037
+      :uri: http://rdaregistry.info/termList/RDATerms/1037
+      :term: digital resource (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1038
+      :uri: http://rdaregistry.info/termList/RDATerms/1038
+      :term: distinctive title
+    - :id: http://rdaregistry.info/termList/RDATerms/1161
+      :uri: http://rdaregistry.info/termList/RDATerms/1161
+      :term: domain
+    - :id: http://rdaregistry.info/termList/RDATerms/1039
+      :uri: http://rdaregistry.info/termList/RDATerms/1039
+      :term: double leaf
+    - :id: http://rdaregistry.info/termList/RDATerms/1040
+      :uri: http://rdaregistry.info/termList/RDATerms/1040
+      :term: early printed resource
+    - :id: http://rdaregistry.info/termList/RDATerms/1041
+      :uri: http://rdaregistry.info/termList/RDATerms/1041
+      :term: element
+    - :id: http://rdaregistry.info/termList/RDATerms/1182
+      :uri: http://rdaregistry.info/termList/RDATerms/1182
+      :term: element set (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1109
+      :uri: http://rdaregistry.info/termList/RDATerms/1109
+      :term: element subtype
+    - :id: http://rdaregistry.info/termList/RDATerms/1116
+      :uri: http://rdaregistry.info/termList/RDATerms/1116
+      :term: element supertype
+    - :id: http://rdaregistry.info/termList/RDATerms/1114
+      :uri: http://rdaregistry.info/termList/RDATerms/1114
+      :term: entity
+    - :id: http://rdaregistry.info/termList/RDATerms/1042
+      :uri: http://rdaregistry.info/termList/RDATerms/1042
+      :term: explanatory reference
+    - :id: http://rdaregistry.info/termList/RDATerms/1043
+      :uri: http://rdaregistry.info/termList/RDATerms/1043
+      :term: finding aid
+    - :id: http://rdaregistry.info/termList/RDATerms/1044
+      :uri: http://rdaregistry.info/termList/RDATerms/1044
+      :term: formally presented
+    - :id: http://rdaregistry.info/termList/RDATerms/1045
+      :uri: http://rdaregistry.info/termList/RDATerms/1045
+      :term: gathering
+    - :id: http://rdaregistry.info/termList/RDATerms/1046
+      :uri: http://rdaregistry.info/termList/RDATerms/1046
+      :term: government
+    - :id: http://rdaregistry.info/termList/RDATerms/1047
+      :uri: http://rdaregistry.info/termList/RDATerms/1047
+      :term: harmony
+    - :id: http://rdaregistry.info/termList/RDATerms/1048
+      :uri: http://rdaregistry.info/termList/RDATerms/1048
+      :term: hierarchical description (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1163
+      :uri: http://rdaregistry.info/termList/RDATerms/1163
+      :term: high-level relationship
+    - :id: http://rdaregistry.info/termList/RDATerms/1049
+      :uri: http://rdaregistry.info/termList/RDATerms/1049
+      :term: identifiable subject system (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1050
+      :uri: http://rdaregistry.info/termList/RDATerms/1050
+      :term: image description
+    - :id: http://rdaregistry.info/termList/RDATerms/1141
+      :uri: http://rdaregistry.info/termList/RDATerms/1141
+      :term: information resource
+    - :id: http://rdaregistry.info/termList/RDATerms/1175
+      :uri: http://rdaregistry.info/termList/RDATerms/1175
+      :term: instance
+    - :id: http://rdaregistry.info/termList/RDATerms/1133
+      :uri: http://rdaregistry.info/termList/RDATerms/1133
+      :term: integrating work
+    - :id: http://rdaregistry.info/termList/RDATerms/1051
+      :uri: http://rdaregistry.info/termList/RDATerms/1051
+      :term: international intergovernmental body
+    - :id: http://rdaregistry.info/termList/RDATerms/1052
+      :uri: http://rdaregistry.info/termList/RDATerms/1052
+      :term: issue (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1053
+      :uri: http://rdaregistry.info/termList/RDATerms/1053
+      :term: iteration
+    - :id: http://rdaregistry.info/termList/RDATerms/1054
+      :uri: http://rdaregistry.info/termList/RDATerms/1054
+      :term: jacket (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1115
+      :uri: http://rdaregistry.info/termList/RDATerms/1115
+      :term: jurisdiction
+    - :id: http://rdaregistry.info/termList/RDATerms/1183
+      :uri: http://rdaregistry.info/termList/RDATerms/1183
+      :term: label
+    - :id: http://rdaregistry.info/termList/RDATerms/1143
+      :uri: http://rdaregistry.info/termList/RDATerms/1143
+      :term: language of description
+    - :id: http://rdaregistry.info/termList/RDATerms/1120
+      :uri: http://rdaregistry.info/termList/RDATerms/1120
+      :term: legal work
+    - :id: http://rdaregistry.info/termList/RDATerms/1189
+      :uri: http://rdaregistry.info/termList/RDATerms/1189
+      :term: linked data vocabulary
+    - :id: http://rdaregistry.info/termList/RDATerms/1178
+      :uri: http://rdaregistry.info/termList/RDATerms/1178
+      :term: liturgical work
+    - :id: http://rdaregistry.info/termList/RDATerms/1055
+      :uri: http://rdaregistry.info/termList/RDATerms/1055
+      :term: logical unit
+    - :id: http://rdaregistry.info/termList/RDATerms/1056
+      :uri: http://rdaregistry.info/termList/RDATerms/1056
+      :term: main series (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1057
+      :uri: http://rdaregistry.info/termList/RDATerms/1057
+      :term: map series
+    - :id: http://rdaregistry.info/termList/RDATerms/1184
+      :uri: http://rdaregistry.info/termList/RDATerms/1184
+      :term: mapping
+    - :id: http://rdaregistry.info/termList/RDATerms/1058
+      :uri: http://rdaregistry.info/termList/RDATerms/1058
+      :term: media
+    - :id: http://rdaregistry.info/termList/RDATerms/1146
+      :uri: http://rdaregistry.info/termList/RDATerms/1146
+      :term: metadata description set
+    - :id: http://rdaregistry.info/termList/RDATerms/1145
+      :uri: http://rdaregistry.info/termList/RDATerms/1145
+      :term: metadata statement
+    - :id: http://rdaregistry.info/termList/RDATerms/1151
+      :uri: http://rdaregistry.info/termList/RDATerms/1151
+      :term: metadata work
+    - :id: http://rdaregistry.info/termList/RDATerms/1059
+      :uri: http://rdaregistry.info/termList/RDATerms/1059
+      :term: microfilm
+    - :id: http://rdaregistry.info/termList/RDATerms/1060
+      :uri: http://rdaregistry.info/termList/RDATerms/1060
+      :term: monograph (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1171
+      :uri: http://rdaregistry.info/termList/RDATerms/1171
+      :term: moving image work
+    - :id: http://rdaregistry.info/termList/RDATerms/1061
+      :uri: http://rdaregistry.info/termList/RDATerms/1061
+      :term: multilevel description (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1118
+      :uri: http://rdaregistry.info/termList/RDATerms/1118
+      :term: musical work
+    - :id: http://rdaregistry.info/termList/RDATerms/1062
+      :uri: http://rdaregistry.info/termList/RDATerms/1062
+      :term: name
+    - :id: http://rdaregistry.info/termList/RDATerms/1063
+      :uri: http://rdaregistry.info/termList/RDATerms/1063
+      :term: neat line
+    - :id: http://rdaregistry.info/termList/RDATerms/1064
+      :uri: http://rdaregistry.info/termList/RDATerms/1064
+      :term: non-self-describing manifestation
+    - :id: http://rdaregistry.info/termList/RDATerms/1166
+      :uri: http://rdaregistry.info/termList/RDATerms/1166
+      :term: notation
+    - :id: http://rdaregistry.info/termList/RDATerms/1172
+      :uri: http://rdaregistry.info/termList/RDATerms/1172
+      :term: object work
+    - :id: http://rdaregistry.info/termList/RDATerms/1134
+      :uri: http://rdaregistry.info/termList/RDATerms/1134
+      :term: official communication
+    - :id: http://rdaregistry.info/termList/RDATerms/1185
+      :uri: http://rdaregistry.info/termList/RDATerms/1185
+      :term: ontology
+    - :id: http://rdaregistry.info/termList/RDATerms/1169
+      :uri: http://rdaregistry.info/termList/RDATerms/1169
+      :term: parallel aggregate
+    - :id: http://rdaregistry.info/termList/RDATerms/1065
+      :uri: http://rdaregistry.info/termList/RDATerms/1065
+      :term: part (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1066
+      :uri: http://rdaregistry.info/termList/RDATerms/1066
+      :term: patronymic
+    - :id: http://rdaregistry.info/termList/RDATerms/1153
+      :uri: http://rdaregistry.info/termList/RDATerms/1153
+      :term: performance
+    - :id: http://rdaregistry.info/termList/RDATerms/1124
+      :uri: http://rdaregistry.info/termList/RDATerms/1124
+      :term: photographic work
+    - :id: http://rdaregistry.info/termList/RDATerms/1067
+      :uri: http://rdaregistry.info/termList/RDATerms/1067
+      :term: physical unit
+    - :id: http://rdaregistry.info/termList/RDATerms/1068
+      :uri: http://rdaregistry.info/termList/RDATerms/1068
+      :term: plate
+    - :id: http://rdaregistry.info/termList/RDATerms/1069
+      :uri: http://rdaregistry.info/termList/RDATerms/1069
+      :term: preferred name
+    - :id: http://rdaregistry.info/termList/RDATerms/1070
+      :uri: http://rdaregistry.info/termList/RDATerms/1070
+      :term: primary relationship (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1186
+      :uri: http://rdaregistry.info/termList/RDATerms/1186
+      :term: property
+    - :id: http://rdaregistry.info/termList/RDATerms/1071
+      :uri: http://rdaregistry.info/termList/RDATerms/1071
+      :term: protocol
+    - :id: http://rdaregistry.info/termList/RDATerms/1072
+      :uri: http://rdaregistry.info/termList/RDATerms/1072
+      :term: pseudonym
+    - :id: http://rdaregistry.info/termList/RDATerms/1135
+      :uri: http://rdaregistry.info/termList/RDATerms/1135
+      :term: published manifestation
+    - :id: http://rdaregistry.info/termList/RDATerms/1162
+      :uri: http://rdaregistry.info/termList/RDATerms/1162
+      :term: range
+    - :id: http://rdaregistry.info/termList/RDATerms/1122
+      :uri: http://rdaregistry.info/termList/RDATerms/1122
+      :term: RDA base carrier category
+    - :id: http://rdaregistry.info/termList/RDATerms/1123
+      :uri: http://rdaregistry.info/termList/RDATerms/1123
+      :term: RDA base content category
+    - :id: http://rdaregistry.info/termList/RDATerms/1159
+      :uri: http://rdaregistry.info/termList/RDATerms/1159
+      :term: real-world object
+    - :id: http://rdaregistry.info/termList/RDATerms/1073
+      :uri: http://rdaregistry.info/termList/RDATerms/1073
+      :term: reference
+    - :id: http://rdaregistry.info/termList/RDATerms/1074
+      :uri: http://rdaregistry.info/termList/RDATerms/1074
+      :term: reference source (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1107
+      :uri: http://rdaregistry.info/termList/RDATerms/1107
+      :term: related resource (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1160
+      :uri: http://rdaregistry.info/termList/RDATerms/1160
+      :term: relationship
+    - :id: http://rdaregistry.info/termList/RDATerms/1075
+      :uri: http://rdaregistry.info/termList/RDATerms/1075
+      :term: relationship designator (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1111
+      :uri: http://rdaregistry.info/termList/RDATerms/1111
+      :term: relationship element
+    - :id: http://rdaregistry.info/termList/RDATerms/1136
+      :uri: http://rdaregistry.info/termList/RDATerms/1136
+      :term: religious work
+    - :id: http://rdaregistry.info/termList/RDATerms/1076
+      :uri: http://rdaregistry.info/termList/RDATerms/1076
+      :term: reproduction
+    - :id: http://rdaregistry.info/termList/RDATerms/1077
+      :uri: http://rdaregistry.info/termList/RDATerms/1077
+      :term: resource entity
+    - :id: http://rdaregistry.info/termList/RDATerms/1078
+      :uri: http://rdaregistry.info/termList/RDATerms/1078
+      :term: running title
+    - :id: http://rdaregistry.info/termList/RDATerms/1144
+      :uri: http://rdaregistry.info/termList/RDATerms/1144
+      :term: script of description
+    - :id: http://rdaregistry.info/termList/RDATerms/1079
+      :uri: http://rdaregistry.info/termList/RDATerms/1079
+      :term: scroll
+    - :id: http://rdaregistry.info/termList/RDATerms/1106
+      :uri: http://rdaregistry.info/termList/RDATerms/1106
+      :term: section (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1080
+      :uri: http://rdaregistry.info/termList/RDATerms/1080
+      :term: self-describing manifestation
+    - :id: http://rdaregistry.info/termList/RDATerms/1187
+      :uri: http://rdaregistry.info/termList/RDATerms/1187
+      :term: semantic map
+    - :id: http://rdaregistry.info/termList/RDATerms/1137
+      :uri: http://rdaregistry.info/termList/RDATerms/1137
+      :term: serial work
+    - :id: http://rdaregistry.info/termList/RDATerms/1081
+      :uri: http://rdaregistry.info/termList/RDATerms/1081
+      :term: series
+    - :id: http://rdaregistry.info/termList/RDATerms/1082
+      :uri: http://rdaregistry.info/termList/RDATerms/1082
+      :term: series title page (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1083
+      :uri: http://rdaregistry.info/termList/RDATerms/1083
+      :term: short title of a legal work
+    - :id: http://rdaregistry.info/termList/RDATerms/1084
+      :uri: http://rdaregistry.info/termList/RDATerms/1084
+      :term: sign language
+    - :id: http://rdaregistry.info/termList/RDATerms/1158
+      :uri: http://rdaregistry.info/termList/RDATerms/1158
+      :term: single work
+    - :id: http://rdaregistry.info/termList/RDATerms/1085
+      :uri: http://rdaregistry.info/termList/RDATerms/1085
+      :term: source of information
+    - :id: http://rdaregistry.info/termList/RDATerms/1157
+      :uri: http://rdaregistry.info/termList/RDATerms/1157
+      :term: static work
+    - :id: http://rdaregistry.info/termList/RDATerms/1170
+      :uri: http://rdaregistry.info/termList/RDATerms/1170
+      :term: still image work
+    - :id: http://rdaregistry.info/termList/RDATerms/1086
+      :uri: http://rdaregistry.info/termList/RDATerms/1086
+      :term: storage medium
+    - :id: http://rdaregistry.info/termList/RDATerms/1138
+      :uri: http://rdaregistry.info/termList/RDATerms/1138
+      :term: string
+    - :id: http://rdaregistry.info/termList/RDATerms/1112
+      :uri: http://rdaregistry.info/termList/RDATerms/1112
+      :term: string encoding scheme
+    - :id: http://rdaregistry.info/termList/RDATerms/1087
+      :uri: http://rdaregistry.info/termList/RDATerms/1087
+      :term: structured description (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1190
+      :uri: http://rdaregistry.info/termList/RDATerms/1190
+      :term: entity subtype
+    - :id: http://rdaregistry.info/termList/RDATerms/1113
+      :uri: http://rdaregistry.info/termList/RDATerms/1113
+      :term: subelement
+    - :id: http://rdaregistry.info/termList/RDATerms/1191
+      :uri: http://rdaregistry.info/termList/RDATerms/1191
+      :term: subproperty
+    - :id: http://rdaregistry.info/termList/RDATerms/1088
+      :uri: http://rdaregistry.info/termList/RDATerms/1088
+      :term: subject (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1089
+      :uri: http://rdaregistry.info/termList/RDATerms/1089
+      :term: subordinate body
+    - :id: http://rdaregistry.info/termList/RDATerms/1090
+      :uri: http://rdaregistry.info/termList/RDATerms/1090
+      :term: subseries (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1091
+      :uri: http://rdaregistry.info/termList/RDATerms/1091
+      :term: subtitle
+    - :id: http://rdaregistry.info/termList/RDATerms/1092
+      :uri: http://rdaregistry.info/termList/RDATerms/1092
+      :term: subunit
+    - :id: http://rdaregistry.info/termList/RDATerms/1139
+      :uri: http://rdaregistry.info/termList/RDATerms/1139
+      :term: successive work
+    - :id: http://rdaregistry.info/termList/RDATerms/1110
+      :uri: http://rdaregistry.info/termList/RDATerms/1110
+      :term: superelement
+    - :id: http://rdaregistry.info/termList/RDATerms/1179
+      :uri: http://rdaregistry.info/termList/RDATerms/1179
+      :term: term of address
+    - :id: http://rdaregistry.info/termList/RDATerms/1165
+      :uri: http://rdaregistry.info/termList/RDATerms/1165
+      :term: textual work
+    - :id: http://rdaregistry.info/termList/RDATerms/1093
+      :uri: http://rdaregistry.info/termList/RDATerms/1093
+      :term: thematic index
+    - :id: http://rdaregistry.info/termList/RDATerms/1094
+      :uri: http://rdaregistry.info/termList/RDATerms/1094
+      :term: title frame (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1095
+      :uri: http://rdaregistry.info/termList/RDATerms/1095
+      :term: title page (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1096
+      :uri: http://rdaregistry.info/termList/RDATerms/1096
+      :term: title screen (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1148
+      :uri: http://rdaregistry.info/termList/RDATerms/1148
+      :term: transcription standard
+    - :id: http://rdaregistry.info/termList/RDATerms/1097
+      :uri: http://rdaregistry.info/termList/RDATerms/1097
+      :term: treaty
+    - :id: http://rdaregistry.info/termList/RDATerms/1098
+      :uri: http://rdaregistry.info/termList/RDATerms/1098
+      :term: type of composition
+    - :id: http://rdaregistry.info/termList/RDATerms/1099
+      :uri: http://rdaregistry.info/termList/RDATerms/1099
+      :term: unit
+    - :id: http://rdaregistry.info/termList/RDATerms/1140
+      :uri: http://rdaregistry.info/termList/RDATerms/1140
+      :term: unpublished manifestation
+    - :id: http://rdaregistry.info/termList/RDATerms/1100
+      :uri: http://rdaregistry.info/termList/RDATerms/1100
+      :term: unstructured description (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1101
+      :uri: http://rdaregistry.info/termList/RDATerms/1101
+      :term: updating loose-leaf
+    - :id: http://rdaregistry.info/termList/RDATerms/1164
+      :uri: http://rdaregistry.info/termList/RDATerms/1164
+      :term: user task
+    - :id: http://rdaregistry.info/termList/RDATerms/1188
+      :uri: http://rdaregistry.info/termList/RDATerms/1188
+      :term: value vocabulary (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1102
+      :uri: http://rdaregistry.info/termList/RDATerms/1102
+      :term: variant access point 
+    - :id: http://rdaregistry.info/termList/RDATerms/1103
+      :uri: http://rdaregistry.info/termList/RDATerms/1103
+      :term: variant name
+    - :id: http://rdaregistry.info/termList/RDATerms/1104
+      :uri: http://rdaregistry.info/termList/RDATerms/1104
+      :term: video tape
+    - :id: http://rdaregistry.info/termList/RDATerms/1105
+      :uri: http://rdaregistry.info/termList/RDATerms/1105
+      :term: vocabulary encoding scheme
+    - :id: http://rdaregistry.info/termList/RDATerms/1173
+      :uri: http://rdaregistry.info/termList/RDATerms/1173
+      :term: vocal work
+    - :id: http://rdaregistry.info/termList/RDATerms/1156
+      :uri: http://rdaregistry.info/termList/RDATerms/1156
+      :term: WEM lock
+    - :id: http://rdaregistry.info/termList/RDATerms/1149
+      :uri: http://rdaregistry.info/termList/RDATerms/1149
+      :term: work group
+    - :id: http://rdaregistry.info/termList/RDATerms/1192
+      :uri: http://rdaregistry.info/termList/RDATerms/1192
+      :term: shortcut
+    - :id: http://rdaregistry.info/termList/RDATerms/1193
+      :uri: http://rdaregistry.info/termList/RDATerms/1193
+      :term: entity supertype
+    - :id: http://rdaregistry.info/termList/RDATerms/1194
+      :uri: http://rdaregistry.info/termList/RDATerms/1194
+      :term: entity boundary
+    - :id: http://rdaregistry.info/termList/RDATerms/1195
+      :uri: http://rdaregistry.info/termList/RDATerms/1195
+      :term: conformance
+    - :id: http://rdaregistry.info/termList/RDATerms/1196
+      :uri: http://rdaregistry.info/termList/RDATerms/1196
+      :term: indirect conformance
+    - :id: http://rdaregistry.info/termList/RDATerms/1197
+      :uri: http://rdaregistry.info/termList/RDATerms/1197
+      :term: title
+    - :id: http://rdaregistry.info/termList/RDATerms/1198
+      :uri: http://rdaregistry.info/termList/RDATerms/1198
+      :term: variant title
+    - :id: http://rdaregistry.info/termList/RDATerms/1202
+      :uri: http://rdaregistry.info/termList/RDATerms/1202
+      :term: preferred title
+    - :id: http://rdaregistry.info/termList/RDATerms/1203
+      :uri: http://rdaregistry.info/termList/RDATerms/1203
+      :term: direct conformance
+    - :id: http://rdaregistry.info/termList/RDATerms/1204
+      :uri: http://rdaregistry.info/termList/RDATerms/1204
+      :term: partial conformance
+    - :id: http://rdaregistry.info/termList/RDATerms/1205
+      :uri: http://rdaregistry.info/termList/RDATerms/1205
+      :term: appellation  
+    - :id: http://rdaregistry.info/termList/RDATerms/1206
+      :uri: http://rdaregistry.info/termList/RDATerms/1206
+      :term: application (Deprecated)
+    - :id: http://rdaregistry.info/termList/RDATerms/1207
+      :uri: http://rdaregistry.info/termList/RDATerms/1207
+      :term: minimum description
+    - :id: http://rdaregistry.info/termList/RDATerms/1208
+      :uri: http://rdaregistry.info/termList/RDATerms/1208
+      :term: effective description
+    - :id: http://rdaregistry.info/termList/RDATerms/1209
+      :uri: http://rdaregistry.info/termList/RDATerms/1209
+      :term: dramatic work
+    - :id: http://rdaregistry.info/termList/RDATerms/1210
+      :uri: http://rdaregistry.info/termList/RDATerms/1210
+      :term: collection work
+    - :id: http://rdaregistry.info/termList/RDATerms/1211
+      :uri: http://rdaregistry.info/termList/RDATerms/1211
+      :term: collection expression
+    - :id: http://rdaregistry.info/termList/RDATerms/1212
+      :uri: http://rdaregistry.info/termList/RDATerms/1212
+      :term: collection manifestation
+    - :id: http://rdaregistry.info/termList/RDATerms/1213
+      :uri: http://rdaregistry.info/termList/RDATerms/1213
+      :term: collection item
+    - :id: http://rdaregistry.info/termList/RDATerms/1214
+      :uri: http://rdaregistry.info/termList/RDATerms/1214
+      :term: unitary finding aid
+    - :id: http://rdaregistry.info/termList/RDATerms/1215
+      :uri: http://rdaregistry.info/termList/RDATerms/1215
+      :term: indexing finding aid
+    - :id: http://rdaregistry.info/termList/RDATerms/1216
+      :uri: http://rdaregistry.info/termList/RDATerms/1216
+      :term: court

--- a/config/authorities/rda_track_configuration.yml
+++ b/config/authorities/rda_track_configuration.yml
@@ -1,0 +1,7 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/trackConfig/1001
+      :uri: http://rdaregistry.info/termList/trackConfig/1001
+      :term: centre track
+    - :id: http://rdaregistry.info/termList/trackConfig/1002
+      :uri: http://rdaregistry.info/termList/trackConfig/1002
+      :term: edge track

--- a/config/authorities/rda_type_of_binding.yml
+++ b/config/authorities/rda_type_of_binding.yml
@@ -1,0 +1,31 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDATypeOfBinding/1004
+      :uri: http://rdaregistry.info/termList/RDATypeOfBinding/1004
+      :term: closed ring binding
+    - :id: http://rdaregistry.info/termList/RDATypeOfBinding/1002
+      :uri: http://rdaregistry.info/termList/RDATypeOfBinding/1002
+      :term: case binding
+    - :id: http://rdaregistry.info/termList/RDATypeOfBinding/1005
+      :uri: http://rdaregistry.info/termList/RDATypeOfBinding/1005
+      :term: open ring binding
+    - :id: http://rdaregistry.info/termList/RDATypeOfBinding/1001
+      :uri: http://rdaregistry.info/termList/RDATypeOfBinding/1001
+      :term: perfect binding
+    - :id: http://rdaregistry.info/termList/RDATypeOfBinding/1003
+      :uri: http://rdaregistry.info/termList/RDATypeOfBinding/1003
+      :term: spiral binding
+    - :id: http://rdaregistry.info/termList/RDATypeOfBinding/1006
+      :uri: http://rdaregistry.info/termList/RDATypeOfBinding/1006
+      :term: springback binding
+    - :id: http://rdaregistry.info/termList/RDATypeOfBinding/1007
+      :uri: http://rdaregistry.info/termList/RDATypeOfBinding/1007
+      :term: saddle stitch binding
+    - :id: http://rdaregistry.info/termList/RDATypeOfBinding/1008
+      :uri: http://rdaregistry.info/termList/RDATypeOfBinding/1008
+      :term: board book binding
+    - :id: http://rdaregistry.info/termList/RDATypeOfBinding/1009
+      :uri: http://rdaregistry.info/termList/RDATypeOfBinding/1009
+      :term: slide binding
+    - :id: http://rdaregistry.info/termList/RDATypeOfBinding/1010
+      :uri: http://rdaregistry.info/termList/RDATypeOfBinding/1010
+      :term: comb binding

--- a/config/authorities/rda_type_of_recording.yml
+++ b/config/authorities/rda_type_of_recording.yml
@@ -1,0 +1,7 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/typeRec/1001
+      :uri: http://rdaregistry.info/termList/typeRec/1001
+      :term: analog
+    - :id: http://rdaregistry.info/termList/typeRec/1002
+      :uri: http://rdaregistry.info/termList/typeRec/1002
+      :term: digital

--- a/config/authorities/rda_unit_of_time.yml
+++ b/config/authorities/rda_unit_of_time.yml
@@ -1,0 +1,40 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1001
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1001
+      :term: century
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1002
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1002
+      :term: hour
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1003
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1003
+      :term: month
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1004
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1004
+      :term: year
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1005
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1005
+      :term: day
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1006
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1006
+      :term: millisecond
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1007
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1007
+      :term: nanosecond
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1008
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1008
+      :term: second
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1009
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1009
+      :term: microsecond
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1010
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1010
+      :term: decade
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1011
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1011
+      :term: millennium
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1012
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1012
+      :term: week
+    - :id: http://rdaregistry.info/termList/RDAUnitOfTime/1013
+      :uri: http://rdaregistry.info/termList/RDAUnitOfTime/1013
+      :term: minute

--- a/config/authorities/rda_user_tasks.yml
+++ b/config/authorities/rda_user_tasks.yml
@@ -1,0 +1,16 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/RDATasks/1005
+      :uri: http://rdaregistry.info/termList/RDATasks/1005
+      :term: explore
+    - :id: http://rdaregistry.info/termList/RDATasks/1001
+      :uri: http://rdaregistry.info/termList/RDATasks/1001
+      :term: find
+    - :id: http://rdaregistry.info/termList/RDATasks/1002
+      :uri: http://rdaregistry.info/termList/RDATasks/1002
+      :term: identify
+    - :id: http://rdaregistry.info/termList/RDATasks/1004
+      :uri: http://rdaregistry.info/termList/RDATasks/1004
+      :term: obtain
+    - :id: http://rdaregistry.info/termList/RDATasks/1003
+      :uri: http://rdaregistry.info/termList/RDATasks/1003
+      :term: select

--- a/config/authorities/rda_video_format.yml
+++ b/config/authorities/rda_video_format.yml
@@ -1,0 +1,46 @@
+:terms:
+    - :id: http://rdaregistry.info/termList/videoFormat/1007
+      :uri: http://rdaregistry.info/termList/videoFormat/1007
+      :term: 8 mm
+    - :id: http://rdaregistry.info/termList/videoFormat/1002
+      :uri: http://rdaregistry.info/termList/videoFormat/1002
+      :term: Betacam
+    - :id: http://rdaregistry.info/termList/videoFormat/1016
+      :uri: http://rdaregistry.info/termList/videoFormat/1016
+      :term: Betacam SP
+    - :id: http://rdaregistry.info/termList/videoFormat/1001
+      :uri: http://rdaregistry.info/termList/videoFormat/1001
+      :term: Betamax
+    - :id: http://rdaregistry.info/termList/videoFormat/1004
+      :uri: http://rdaregistry.info/termList/videoFormat/1004
+      :term: CED
+    - :id: http://rdaregistry.info/termList/videoFormat/1005
+      :uri: http://rdaregistry.info/termList/videoFormat/1005
+      :term: D-2
+    - :id: http://rdaregistry.info/termList/videoFormat/1006
+      :uri: http://rdaregistry.info/termList/videoFormat/1006
+      :term: EIAJ
+    - :id: http://rdaregistry.info/termList/videoFormat/1008
+      :uri: http://rdaregistry.info/termList/videoFormat/1008
+      :term: Hi-8 mm
+    - :id: http://rdaregistry.info/termList/videoFormat/1009
+      :uri: http://rdaregistry.info/termList/videoFormat/1009
+      :term: laser optical
+    - :id: http://rdaregistry.info/termList/videoFormat/1010
+      :uri: http://rdaregistry.info/termList/videoFormat/1010
+      :term: M-II
+    - :id: http://rdaregistry.info/termList/videoFormat/1011
+      :uri: http://rdaregistry.info/termList/videoFormat/1011
+      :term: Quadruplex
+    - :id: http://rdaregistry.info/termList/videoFormat/1012
+      :uri: http://rdaregistry.info/termList/videoFormat/1012
+      :term: Super-VHS
+    - :id: http://rdaregistry.info/termList/videoFormat/1013
+      :uri: http://rdaregistry.info/termList/videoFormat/1013
+      :term: Type C
+    - :id: http://rdaregistry.info/termList/videoFormat/1014
+      :uri: http://rdaregistry.info/termList/videoFormat/1014
+      :term: U-matic
+    - :id: http://rdaregistry.info/termList/videoFormat/1015
+      :uri: http://rdaregistry.info/termList/videoFormat/1015
+      :term: VHS

--- a/script/get_rda_terms.rb
+++ b/script/get_rda_terms.rb
@@ -1,0 +1,82 @@
+# One-off script to fetch rda terms from RDA Reference value vocabularies: https://www.rdaregistry.info/termList/
+# To run: ruby script/get_rda_terms.rb
+
+require 'nokogiri'
+require 'open-uri'
+
+rda_vocabularies = [
+  { href: "AspectRatio", title: "RDA Aspect Ratio Designation" },
+  { href: "bookFormat", title: "RDA Bibliographic Format" },
+  { href: "broadcastStand", title: "RDA Broadcast Standard" },
+  { href: "RDACarrierEU", title: "RDA Carrier Extent Unit" },
+  { href: "RDACarrierType", title: "RDA Carrier Type" },
+  { href: "RDACartoDT", title: "RDA Cartographic Data Type" },
+  { href: "RDACollectionAccrualMethod", title: "RDA Collection Accrual Method" },
+  { href: "RDACollectionAccrualPolicy", title: "RDA Collection Accrual Policy" },
+  { href: "RDAColourContent", title: "RDA Colour Content" },
+  { href: "configPlayback", title: "RDA Configuration of Playback Channels" },
+  { href: "RDAContentType", title: "RDA Content Type" },
+  { href: "RDAExtensionPlan", title: "RDA Extension Plan" },
+  { href: "fileType", title: "RDA File Type" },
+  { href: "fontSize", title: "RDA Font Size" },
+  { href: "MusNotation", title: "RDA Form of Musical Notation" },
+  { href: "noteMove", title: "RDA Form of Notated Movement" },
+  { href: "TacNotation", title: "RDA Form of Tactile Notation" },
+  { href: "formatNoteMus", title: "RDA Format of Notated Music" },
+  { href: "frequency", title: "RDA Frequency" },
+  { href: "RDAGeneration", title: "RDA Generation" },
+  { href: "groovePitch", title: "RDA Groove Pitch of an Analog Cylinder" },
+  { href: "grooveWidth", title: "RDA Groove Width of an Analog Disc" },
+  { href: "IllusContent", title: "RDA Illustrative Content" },
+  { href: "RDAInteractivityMode", title: "RDA Interactivity Mode" },
+  { href: "layout", title: "RDA Layout" },
+  { href: "RDALinkedDataWork", title: "RDA Linked Data Work" },
+  { href: "RDAMaterial", title: "RDA Material" },
+  { href: "RDAMediaType", title: "RDA Media Type" },
+  { href: "ModeIssue", title: "RDA Mode of Issuance" },
+  { href: "RDAPolarity", title: "RDA Polarity" },
+  { href: "presFormat", title: "RDA Presentation Format" },
+  { href: "RDAproductionMethod", title: "RDA Production Method" },
+  { href: "recMedium", title: "RDA Recording Medium" },
+  { href: "RDARecordingMethods", title: "RDA Recording Methods" },
+  { href: "RDARecordingSources", title: "RDA Recording Source" },
+  { href: "RDAReductionRatio", title: "RDA Reduction Ratio Designation" },
+  { href: "RDARegionalEncoding", title: "RDA Regional Encoding" },
+  { href: "scale", title: "RDA Scale Designation" },
+  { href: "soundCont", title: "RDA Sound Content" },
+  { href: "specPlayback", title: "RDA Special Playback Characteristics" },
+  { href: "statIdentification", title: "RDA Status of Identification" },
+  { href: "RDATerms", title: "RDA Terms" },
+  { href: "trackConfig", title: "RDA Track Configuration" },
+  { href: "RDATypeOfBinding", title: "RDA Type of Binding" },
+  { href: "typeRec", title: "RDA Type of Recording" },
+  { href: "RDAUnitOfTime", title: "RDA Unit of Time" },
+  { href: "RDATasks", title: "RDA User Tasks" },
+  { href: "videoFormat", title: "RDA Video Format" }
+]
+
+rda_vocabularies.each do |v|
+  new_filename = "#{v[:title].downcase.gsub(/\s+/, '_')}.yml"
+  doc = Nokogiri::XML(URI.open("https://www.rdaregistry.info/xml/termList/#{v[:href]}.xml"))
+  File.open("config/authorities/#{v[:title].downcase.gsub(/\s+/, '_')}.yml", 'w') do |f|
+    terms_yml = ":terms:\n"
+    concepts = doc.xpath("//rdf:RDF//skos:Concept")
+    raise "No concepts found for #{v}" if concepts.count == 0
+    concepts.map do |concept|
+      uri = concept["rdf:about"]
+      # id = uri.split("/")[-1]
+      term = concept.at_xpath("skos:prefLabel[@xml:lang='en']").text
+
+      raise "Missing info for #{v}" if uri.empty? || term.empty?
+      if uri.include?("termList")
+        terms_yml += "    - :id: #{uri}\n"
+        terms_yml += "      :uri: #{uri}\n"
+        terms_yml += "      :term: #{term}\n"
+      else
+        puts "Skipping uri: #{uri}"
+      end
+    end
+    f.write(terms_yml)
+  end
+  puts "Created #{new_filename}"
+end


### PR DESCRIPTION
- GitHub Issue: https://github.com/cul-it/qa_server/issues/385
- Source of controlled vocabulary: https://www.rdaregistry.info/termList/
- QA documentation on connecting to local controlled vocabulary: https://github.com/samvera/questioning_authority/wiki/Connecting-to-States-local-controlled-vocabulary

This PR includes 48 local controlled vocabulary lists for RDA vocabularies and the script used to generate these yml files.

Ready for review, but waiting to merge until qa gem upgrade branch has been merged in ld4p/qa_server_container because local cv's are missing uri fields in json response in older versions of qa.