### PR TITLE
Add DBPedia direct linked data lookup configs

### DIFF
--- a/config/authorities/linked_data/dbpedia_direct.json
+++ b/config/authorities/linked_data/dbpedia_direct.json
@@ -40,7 +40,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "https://dbpedia.org/sparql?query=CONSTRUCT+%7B+%3Furi+rdfs%3Alabel+%3Flabel%3B+foaf%3Aname+%3Fname%3B+dbo%3Aabstract+%3Fabstract.+%7D+WHERE+%7B+%7B+%3Furi+rdfs%3Alabel+%3FlabelMatch+FILTER%28bif%3Acontains%28%3FlabelMatch%2C+%27%22{query}*%22%27%29+%26%26+langMatches%28lang%28%3FlabelMatch%29%2C%22{lang}%22%29%29+%7D+UNION+%7B+%3Furi+foaf%3Aname+%3FnameMatch+FILTER%28bif%3Acontains%28%3FnameMatch%2C+%27%22{query}*%22%27%29+%26%26+langMatches%28lang%28%3FnameMatch%29%2C%22{lang}%22%29%29+%7D+OPTIONAL+%7B+%3Furi+rdfs%3Alabel+%3Flabel+%7D+OPTIONAL+%7B+%3Furi+foaf%3Aname+%3Fname+%7D+OPTIONAL+%7B%3Furi+dbo%3Aabstract+%3Fabstract+%7D+FILTER%28%28%21bound%28%3Flabel%29+%7C%7C+langMatches%28lang%28%3Flabel%29%2C%22{lang}%22%29%29+%26%26+%28%21bound%28%3Fname%29+%7C%7C+langMatches%28lang%28%3Fname%29%2C%22{lang}%22%29%29+%26%26+%28%21bound%28%3Fabstract%29+%7C%7C+langMatches%28lang%28%3Fabstract%29%2C%22{lang}%22%29%29%29+%7D&format=application%2Frdf%2Bxml&timeout=30000",
+      "template": "https://dbpedia.org/sparql?query=CONSTRUCT+%7B+%3Furi+rdfs%3Alabel+%3Flabel%3B+foaf%3Aname+%3Fname%3B+dbo%3Aabstract+%3Fabstract.+%7D+WHERE+%7B+%7B+%3Furi+rdfs%3Alabel+%3FlabelMatch+FILTER%28bif%3Acontains%28%3FlabelMatch%2C+%27%22{query}%22%27%29+%26%26+langMatches%28lang%28%3FlabelMatch%29%2C%22{lang}%22%29%29+%7D+UNION+%7B+%3Furi+foaf%3Aname+%3FnameMatch+FILTER%28bif%3Acontains%28%3FnameMatch%2C+%27%22{query}%22%27%29+%26%26+langMatches%28lang%28%3FnameMatch%29%2C%22{lang}%22%29%29+%7D+OPTIONAL+%7B+%3Furi+rdfs%3Alabel+%3Flabel+%7D+OPTIONAL+%7B+%3Furi+foaf%3Aname+%3Fname+%7D+OPTIONAL+%7B%3Furi+dbo%3Aabstract+%3Fabstract+%7D+FILTER%28%28%21bound%28%3Flabel%29+%7C%7C+langMatches%28lang%28%3Flabel%29%2C%22{lang}%22%29%29+%26%26+%28%21bound%28%3Fname%29+%7C%7C+langMatches%28lang%28%3Fname%29%2C%22{lang}%22%29%29+%26%26+%28%21bound%28%3Fabstract%29+%7C%7C+langMatches%28lang%28%3Fabstract%29%2C%22{lang}%22%29%29%29+%7D&format=application%2Frdf%2Bxml&timeout=30000",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -64,7 +64,7 @@
       "lang":    "lang"
     },
     "results": {
-      "label_ldpath":  "rdfs:label :: xsd:string"
+      "label_ldpath":  "rdfs:label | fn:first(rdfs:label, fn:strJoin(foaf:name, ', ')) :: xsd:string"
     },
     "context": {
       "properties": [

--- a/config/authorities/linked_data/dbpedia_direct.json
+++ b/config/authorities/linked_data/dbpedia_direct.json
@@ -1,7 +1,7 @@
 {
   "QA_CONFIG_VERSION": "2.1",
   "prefixes": {
-    "dbpedia": "http://dbpedia.org/property/"
+    "dbo": "http://dbpedia.org/ontology/"
   },
   "term": {
     "url": {
@@ -36,5 +36,54 @@
       "sameas_ldpath": "owl:sameAs ::xsd:anyURI"
     }
   },
-  "search": {}
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "https://dbpedia.org/sparql?query=CONSTRUCT+%7B+%3Furi+rdfs%3Alabel+%3Flabel%3B+foaf%3Aname+%3Fname%3B+dbo%3Aabstract+%3Fabstract.+%7D+WHERE+%7B+%7B+%3Furi+rdfs%3Alabel+%3FlabelMatch+FILTER%28bif%3Acontains%28%3FlabelMatch%2C+%27%22{query}*%22%27%29+%26%26+langMatches%28lang%28%3FlabelMatch%29%2C%22{lang}%22%29%29+%7D+UNION+%7B+%3Furi+foaf%3Aname+%3FnameMatch+FILTER%28bif%3Acontains%28%3FnameMatch%2C+%27%22{query}*%22%27%29+%26%26+langMatches%28lang%28%3FnameMatch%29%2C%22{lang}%22%29%29+%7D+OPTIONAL+%7B+%3Furi+rdfs%3Alabel+%3Flabel+%7D+OPTIONAL+%7B+%3Furi+foaf%3Aname+%3Fname+%7D+OPTIONAL+%7B%3Furi+dbo%3Aabstract+%3Fabstract+%7D+FILTER%28%28%21bound%28%3Flabel%29+%7C%7C+langMatches%28lang%28%3Flabel%29%2C%22{lang}%22%29%29+%26%26+%28%21bound%28%3Fname%29+%7C%7C+langMatches%28lang%28%3Fname%29%2C%22{lang}%22%29%29+%26%26+%28%21bound%28%3Fabstract%29+%7C%7C+langMatches%28lang%28%3Fabstract%29%2C%22{lang}%22%29%29%29+%7D&format=application%2Frdf%2Bxml&timeout=30000",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "lang":    "lang"
+    },
+    "results": {
+      "label_ldpath":  "rdfs:label :: xsd:string"
+    },
+    "context": {
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.dbpedia_direct.label",
+          "property_label_default": "Label",
+          "ldpath": "rdfs:label :: xsd:string"
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.dbpedia_direct.name",
+          "property_label_default": "Name",
+          "ldpath": "foaf:name :: xsd:string"
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.dbpedia_direct.abstract",
+          "property_label_default": "Abstract",
+          "ldpath": "dbo:abstract :: xsd:string"
+        }
+      ]
+    }
+  }
 }

--- a/config/authorities/linked_data/scenarios/dbpedia_direct_validation.yml
+++ b/config/authorities/linked_data/scenarios/dbpedia_direct_validation.yml
@@ -12,16 +12,12 @@ search:
   #------------------
   -
     query: Volleyball
-    position: 5
-    subject_uri: "http://dbpedia.org/resource/Volleyball"
+    position: 9000
+    subject_uri: 'http://dbpedia.org/resource/Volleyball'
   -
-    query: Volleyb
-    position: 5
-    subject_uri: "http://dbpedia.org/resource/Volleyball"
-  -
-    query: volleyb
-    position: 5
-    subject_uri: "http://dbpedia.org/resource/Volleyball"
+    query: Cristiano Ronaldo
+    position: 10
+    subject_uri: 'http://dbpedia.org/resource/Cristiano_Ronaldo'
 term:
   -
     identifier: 'http://dbpedia.org/resource/Barack_Obama'

--- a/config/authorities/linked_data/scenarios/dbpedia_direct_validation.yml
+++ b/config/authorities/linked_data/scenarios/dbpedia_direct_validation.yml
@@ -11,9 +11,9 @@ search:
   #  Accuracy tests
   #------------------
   -
-    query: Volleyball
-    position: 9000
-    subject_uri: 'http://dbpedia.org/resource/Volleyball'
+    query: amphora
+    position: 5
+    subject_uri: 'http://dbpedia.org/resource/Amphora'
   -
     query: Cristiano Ronaldo
     position: 10

--- a/config/authorities/linked_data/scenarios/dbpedia_direct_validation.yml
+++ b/config/authorities/linked_data/scenarios/dbpedia_direct_validation.yml
@@ -1,6 +1,27 @@
 ---
 authority:
   service: direct
+search:
+  #------------------
+  # Connection tests
+  #------------------
+  -
+    query: 'Barack Obama'
+  #------------------
+  #  Accuracy tests
+  #------------------
+  -
+    query: Volleyball
+    position: 5
+    subject_uri: "http://dbpedia.org/resource/Volleyball"
+  -
+    query: Volleyb
+    position: 5
+    subject_uri: "http://dbpedia.org/resource/Volleyball"
+  -
+    query: volleyb
+    position: 5
+    subject_uri: "http://dbpedia.org/resource/Volleyball"
 term:
   -
     identifier: 'http://dbpedia.org/resource/Barack_Obama'

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -10,6 +10,10 @@ en:
   qa:
     linked_data:
       authority:
+        dbpedia_direct:
+          abstract: Abstract
+          label: Label
+          name: Name
         getty_direct:
           parent_body: Parent Body
         homosaurus_direct:


### PR DESCRIPTION
https://github.com/cul-it/qa_server/issues/389

Branched off of rda-local-cv, which is currently blocked from merging on qa upgrade branch in ld4p/qa_server_container (https://github.com/cul-it/qa_server_aws_deploy/pull/38). So this one is also blocked unless I decide to cherry-pick onto a new branch.